### PR TITLE
Fix npm version script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "test": "npm run lint && karma start --single-run",
     "karma": "karma start --autoWatch",
-    "version": "npm version from-git && node scripts/version.js",
+    "version": "node scripts/version.js",
     "postinstall": "node scripts/postinstall.js",
     "build:plugins": "npm run clear:plugins && babel-node --presets=env server/build-plugins.js",
     "clear:plugins": "babel-node --presets=env server/clear-plugins.js"


### PR DESCRIPTION
It turns out, `npm run version` (plus preverion & postversion) scripts get ran by `npm version`, so what we had before behaved how we wanted ^.^

Want to have the UI show the proper version info: `npm run version`
Want to bump the version: `npm version patch`