### PR TITLE
Forward query params to backend server

### DIFF
--- a/server/bcoinRouter.js
+++ b/server/bcoinRouter.js
@@ -7,15 +7,22 @@ const routerWithClient = client => {
   const bcoinRouter = express.Router({ mergeParams: true });
 
   bcoinRouter.all('*', async (req, res, next) => {
-    const { method, path, body } = req;
+    const { method, path, body, query } = req;
+    // use query params for GET request, otherwise use body
+    const payload = method === 'GET' ? query : body;
     try {
       logger.debug(
-        `client: ${client.constructor.name}, method: ${method}, path: ${path}`
+        `client: ${client.constructor.name}, method: ${method},`,
+        // eslint-disable-next-line
+        `path: ${path}, query:`,
+        query,
+        ', body:',
+        body
       );
-      const bcoinResponse = await client.request(method, path, body);
-      logger.debug('server response:', bcoinResponse ? bcoinResponse : 'null');
-      if (bcoinResponse) return res.status(200).json(bcoinResponse);
-      // when bcoinResponse is null due to
+      const response = await client.request(method, path, payload);
+      logger.debug('server response:', response ? response : 'null');
+      if (response) return res.status(200).json(response);
+      // return 404 when response is null due to
       // resource not being found on server
       return res.status(404).json({ message: 'not found' });
     } catch (error) {

--- a/server/bcoinRouter.js
+++ b/server/bcoinRouter.js
@@ -6,19 +6,17 @@ const logger = require('./logger');
 const routerWithClient = client => {
   const bcoinRouter = express.Router({ mergeParams: true });
 
-  bcoinRouter.all('*', async (req, res, next) => {
+  bcoinRouter.all('*', async (req, res) => {
     const { method, path, body, query } = req;
     // use query params for GET request, otherwise use body
     const payload = method === 'GET' ? query : body;
     try {
       logger.debug(
         `client: ${client.constructor.name}, method: ${method},`,
-        // eslint-disable-next-line
-        `path: ${path}, query:`,
-        query,
-        ', body:',
-        body
+        `path: ${path}`
       );
+      logger.debug('query:', query);
+      logger.debug('body:', body);
       const response = await client.request(method, path, payload);
       logger.debug('server response:', response ? response : 'null');
       if (response) return res.status(200).json(response);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,7 +95,7 @@ module.exports = function(env = {}) {
           })
         },
         {
-          test: /\.(png|jpg|gif)$/,
+          test: /\.(png|jpg|gif|eot|svg|ttf|woff|woff2)$/,
           use: [
             {
               loader: 'file-loader',


### PR DESCRIPTION
For requests that require query params, forward the query params. Use the same logic for using query params vs using the request body as in `bcurl`