### PR TITLE
micah/specify node npm versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ a full featured, enterprise level GUI for your Bcoin Bitcoin node.
 
 ## Dependencies
 
-- npm >5.7.1
-- node >8.x
+- npm >=5.7.1
+- node >=8.9.4
 
 NOTE: It is important to be using at least this version of `npm`
 because of a bug that removes `node_modules` that are installed from

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "engines": {
     "node": ">=8.9.4",
-    "npm": ">=5.6.0"
+    "npm": ">=5.7.1"
   },
   "dependencies": {
     "@bpanel/bpanel-ui": "^0.0.7",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
   ],
   "author": "bpanel",
   "license": "MIT",
+  "engines": {
+    "node": ">=8.9.4",
+    "npm": ">=5.6.0"
+  },
   "dependencies": {
     "@bpanel/bpanel-ui": "^0.0.7",
     "@bpanel/bpanel-utils": "0.0.7",


### PR DESCRIPTION
a small PR to enforce minimum versions of node and npm via the engines section of the package.json

https://docs.npmjs.com/files/package.json#engines

I believe these are the correct minimum versions for bpanel master today, based on conversations with @Thann today at #c4yt 

please do suggest different version numbers if they should be different.  what I care about here is the developer friendly automatic warning when using an unsupported node or npm 😄 (not the specific versions per se)