### PR TITLE
Don't log huge responses from the server

### DIFF
--- a/server/bcoinRouter.js
+++ b/server/bcoinRouter.js
@@ -18,7 +18,19 @@ const routerWithClient = client => {
       logger.debug('query:', query);
       logger.debug('body:', body);
       const response = await client.request(method, path, payload);
-      logger.debug('server response:', response ? response : 'null');
+      // prevent logging of potentially huge responses
+      if (
+        path.includes('tx/history') ||
+        (path.includes('tx/last') && Array.isArray(response))
+      ) {
+        logger.debug(
+          `server response (truncated): ${JSON.stringify(
+            response.slice(0, 1)
+          )}, ${response.length} txns total`
+        );
+      } else {
+        logger.debug('server response:', response ? response : 'null');
+      }
       if (response) return res.status(200).json(response);
       // return 404 when response is null due to
       // resource not being found on server


### PR DESCRIPTION
If you have thousands of transactions returning, this would block for a few seconds while it was printing.  This way we don't log everything when we query transaction history. I didn't notice this problem with any other endpoints