### PR TITLE
Experiment - webpack dll

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "version": "node scripts/version.js",
     "postinstall": "node scripts/postinstall.js",
     "build:plugins": "npm run clear:plugins && babel-node --presets=env server/build-plugins.js",
-    "clear:plugins": "babel-node --presets=env server/clear-plugins.js"
+    "clear:plugins": "babel-node --presets=env server/clear-plugins.js",
+    "build:dll": "webpack --config webpack.dll.config.js"
   },
   "lint-staged": {
     "*.{js,json,css,jsx,scss}": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,13 +33,30 @@ const loaders = {
 
 module.exports = function(env = {}) {
   const plugins = [];
-  if (env.dev) {
+
+  if (!env.dev) {
     plugins.push(
       new webpack.optimize.UglifyJsPlugin({
         safari10: true,
         minimize: true,
         sourceMap: true,
         compress: { warnings: false }
+      })
+    );
+  }
+
+  if (env.dev) {
+    const vendorManifest = path.join(
+      __dirname,
+      './dist',
+      'vendor-manifest.json'
+    );
+
+    plugins.push(
+      new webpack.DllReferencePlugin({
+        manifest: require(vendorManifest),
+        name: 'vendor_lib',
+        scope: 'mapped'
       })
     );
   }
@@ -51,7 +68,8 @@ module.exports = function(env = {}) {
     devtool: 'eval-source-map',
     output: {
       filename: '[name].bundle.js',
-      path: path.resolve(__dirname, 'dist')
+      path: path.resolve(__dirname, 'dist'),
+      libraryTarget: 'umd'
     },
     watchOptions: {
       poll: env.poll && (parseInt(env.poll) || 1000),

--- a/webpack.dll.config.js
+++ b/webpack.dll.config.js
@@ -1,0 +1,35 @@
+const webpack = require('webpack');
+const path = require('path');
+
+const vendorManifest = path.join(__dirname, 'dist', '[name]-manifest.json');
+
+module.exports = {
+  target: 'web',
+  entry: {
+    vendor: [
+      'bcoin/lib/bcoin-browser',
+      'bclient',
+      'react',
+      'react-redux',
+      'react-dom',
+      '@bpanel/bpanel-ui',
+      '@bpanel/bpanel-utils'
+    ]
+  },
+  output: {
+    libraryTarget: 'umd',
+    path: path.join(__dirname, 'dist'),
+    library: '[name]_lib',
+    filename: 'vendor.js'
+  },
+  resolve: {
+    modules: ['node_modules'],
+    extensions: ['-browser.js', '.js', '.json']
+  },
+  plugins: [
+    new webpack.DllPlugin({
+      name: '[name]_lib',
+      path: vendorManifest
+    })
+  ]
+};


### PR DESCRIPTION
This is the webpack DLLPlugin experiment.

Try and experiment with it, see if it gives performance boost and how can we use this for development environment.

* Added script - `npm run build:dll` - which is necessary in development mode (to run once, and if you update the plugins listed in webpack.dll.config.js.
* Fixes minor problem - Uglify was used in dev mode.