### PR TITLE
Move error listeners into codepath

### DIFF
--- a/server/bcoinSocket.js
+++ b/server/bcoinSocket.js
@@ -1,8 +1,13 @@
 const logger = require('./logger');
 
 const socketHandler = (nodeClient, walletClient) => {
+  // setup error handling
+  nodeClient.on('error', err => logger.error('Socket error (node): ', err));
+  walletClient.on('error', err => logger.error('Socket error (wallet): ', err));
+
   const walletPrefix = 'wallet ';
   const subscriptions = {}; // cache to manage subscriptions made by clients
+
   return async socket => {
     // broadcasts only send messages to the bcoin node
     // but originating socket does not expect a response
@@ -87,20 +92,13 @@ const socketHandler = (nodeClient, walletClient) => {
       } else {
         logger.debug(`Subscribing to "${event}" event on bcoin node`);
         nodeClient.bind(event, (...data) => {
-          // logger.debug(
-          //   `Event "${event}" received from node.`,
-          //   `Firing "${responseEvent}" event`
-          // );
+          logger.debug(
+            `Event "${event}" received from node.`,
+            `Firing "${responseEvent}" event`
+          );
           socket.fire(responseEvent, ...data);
         });
       }
-    });
-
-    nodeClient.on('error', err => {
-      logger.error('Socket error (node): ', err);
-    });
-    walletClient.on('error', err => {
-      logger.error('Socket error (wallet): ', err);
     });
   };
 };

--- a/server/index.js
+++ b/server/index.js
@@ -132,10 +132,15 @@ module.exports = config => {
 
     app.get('/*', resolveIndex);
 
-    // Handle the unhandled
+    // handle the unhandled rejections and exceptions
     if (process.listenerCount('unhandledRejection') === 0) {
-      process.on('unhandledRejection', function(err) {
-        throw err;
+      process.on('unhandledRejection', err => {
+        logger.error('Unhandled Rejection\n', err);
+      });
+    }
+    if (process.listenerCount('uncaughtException') === 0) {
+      process.on('uncaughtException', err => {
+        logger.error('Uncaught Exception\n', err);
       });
     }
 


### PR DESCRIPTION
Previously the error handlers were not being added because they were unreachable, they came after a `return` statement. Now the error handling happens first thing inside of the function