### PR TITLE
Fix state update problems

### DIFF
--- a/webapp/store/reducers/chain.js
+++ b/webapp/store/reducers/chain.js
@@ -10,7 +10,7 @@ const chainState = (state = initialState, action) => {
   let newState = { ...state };
   switch (action.type) {
     case SET_CHAIN_INFO: {
-      newState = action.payload;
+      newState = { ...state, ...action.payload };
       return newState;
     }
 


### PR DESCRIPTION
We were overwriting the whole state on chain updates which was getting rid of some custom information. This fixes it. Not sure what the lesson/fix is to avoid this in the future. Basic rule is that we should avoid overwriting whole portions of the state and instead use spread operators to merge. This I guess is one advantage of having something like immutable... Good news is that this wasn't in a plugin although there's nothing stopping a plugin developer from making this same mistake. 