### PR TITLE
fix footer flicker by rearranging components and using bootstrap classes

### DIFF
--- a/webapp/components/Footer.js
+++ b/webapp/components/Footer.js
@@ -27,16 +27,16 @@ class Footer extends PureComponent {
     let FooterWidget;
     if (!Array.isArray(footerWidgets)) FooterWidget = footerWidgets;
     return (
-      <div className="container-fluid">
-        <footer className={`${theme.footer.container} row align-items-center`}>
+      <footer className="fixed-bottom">
+        <div className={`${theme.footer.container} d-flex align-items-center`}>
           {Array.isArray(footerWidgets) ? (
             footerWidgets.map((Widget, index) => <Widget key={index} />)
           ) : (
             <FooterWidget />
           )}
           {CustomChildren && <CustomChildren />}
-        </footer>
-      </div>
+        </div>
+      </footer>
     );
   }
 }

--- a/webapp/config/themeConfig/themeCreator.js
+++ b/webapp/config/themeConfig/themeCreator.js
@@ -116,7 +116,7 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
     app: {
       container: {
         height: appHeight,
-        overflowY: 'overlay'
+        overflowY: 'auto'
       },
       body: {
         color: themeColors.primary,
@@ -128,7 +128,6 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
         fontFamily
       },
       content: {
-        height: `calc(100vh - ${footerHeight} - ${headerHeight})`,
         ...makeGutter('padding', { left: 1.25, right: 2.5 })
       },
       sidebarContainer: {
@@ -139,7 +138,6 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
     // Sidebar
     sidebar: {
       container: {
-        height: appHeight,
         minHeight: '50vh',
         ...makeGutter('padding', { left: 0 })
       },
@@ -185,7 +183,7 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
         width: makeRem(3.75, fontSizeBase)
       },
       footer: {
-        ...makeGutter('padding', { bottom: 3.125 })
+        // ...makeGutter('padding', { bottom: 3.125 })
       },
       footerText: {
         fontSize: fontSizeSmall,

--- a/webapp/containers/App/App.js
+++ b/webapp/containers/App/App.js
@@ -80,26 +80,30 @@ class App extends PureComponent {
     const { sortedPluginMeta, location, theme } = this.props;
     return (
       <ThemeProvider theme={theme}>
-        <div className={`${theme.app.container} container-fluid`} role="main">
-          <div className="row">
-            <div className={`${theme.app.sidebarContainer} col-sm-4 col-lg-3`}>
-              <Sidebar
-                sidebarNavItems={sortedPluginMeta}
-                location={location}
-                theme={theme}
-              />
+        <div>
+          <div className={`${theme.app.container} container-fluid`} role="main">
+            <div className="row">
+              <div
+                className={`${theme.app.sidebarContainer} col-sm-4 col-lg-3`}
+              >
+                <Sidebar
+                  sidebarNavItems={sortedPluginMeta}
+                  location={location}
+                  theme={theme}
+                />
+              </div>
+              <div className={`${theme.app.content} col-sm-8 col-lg-9`}>
+                <Header />
+                <Route
+                  exact
+                  path="/"
+                  render={() => <Redirect to={`/${this.getHomePath()}`} />}
+                />
+                <Panel />
+              </div>
             </div>
-            <div className={`${theme.app.content} col-sm-8 col-lg-9`}>
-              <Header />
-              <Route
-                exact
-                path="/"
-                render={() => <Redirect to={`/${this.getHomePath()}`} />}
-              />
-              <Panel />
-            </div>
-            <Footer />
           </div>
+          <Footer />
         </div>
       </ThemeProvider>
     );


### PR DESCRIPTION
Wanted to fix this as it was making development (and demoing) just a little more annoying than it needed to be. Scrolling and DOM interaction (e.g. expanding row) is much smoother now. 

Tested in latest versions of Chrome, Safari, Firefox, and Brave. 