### PR TITLE
pass host to socket connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@bpanel/bpanel-ui": "^0.0.7",
-    "@bpanel/bpanel-utils": "^0.0.8",
+    "@bpanel/bpanel-utils": "^0.0.9",
     "aphrodite": "^1.2.5",
     "autoprefixer": "^7.1.5",
     "babel-cli": "^6.26.0",

--- a/webapp/store/actions/socketActions.js
+++ b/webapp/store/actions/socketActions.js
@@ -1,10 +1,12 @@
 import { CONNECT_SOCKET, DISCONNECT_SOCKET } from '../constants/sockets';
+import { bpanelClient } from '@bpanel/bpanel-utils';
 
 export function connectSocket() {
+  const client = bpanelClient();
   return {
     type: CONNECT_SOCKET,
     bsock: {
-      host: 'localhost',
+      host: client.host ? client.host : 'localhost',
       port: 8000
     }
   };


### PR DESCRIPTION
Will go together with 0.0.9 of bpanel-utils which retrieves the `window.location.hostname` and sets on the client singletons.