### PR TITLE
Add and remove side navigation items w/ support for child paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -502,12 +502,6 @@
         }
       }
     },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -560,12 +554,6 @@
         "postcss": "^6.0.17",
         "postcss-value-parser": "^3.2.3"
       }
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
     },
     "aws4": {
       "version": "1.7.0",
@@ -1536,9 +1524,9 @@
       "from": "github:bcoin-org/bcoin",
       "requires": {
         "bcfg": "~0.1.0",
-        "bclient": "~0.1.0",
-        "bcrypto": "~0.3.1",
-        "bdb": "~0.2.0",
+        "bclient": "~0.1.1",
+        "bcrypto": "~0.3.7",
+        "bdb": "~0.2.1",
         "bdns": "~0.1.0",
         "bevent": "~0.1.0",
         "bfile": "~0.1.0",
@@ -1558,7 +1546,7 @@
         "bufio": "~0.2.0",
         "bupnp": "~0.2.1",
         "bval": "~0.1.0",
-        "bweb": "~0.1.0",
+        "bweb": "~0.1.1",
         "mrmr": "~0.1.0",
         "n64": "~0.2.0"
       },
@@ -1592,7 +1580,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-
     "bcrypto": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-0.3.7.tgz",
@@ -2270,6 +2257,7 @@
       "version": "github:bcoin-org/bsock#a8b996da6e30fd87bf97809f1ee63760cf594186",
       "from": "github:bcoin-org/bsock",
       "requires": {
+        "bsert": "~0.0.3",
         "faye-websocket": "~0.11.1"
       }
     },
@@ -2286,6 +2274,7 @@
           "version": "git+https://github.com/bcoin-org/bsock.git#a8b996da6e30fd87bf97809f1ee63760cf594186",
           "from": "git+https://github.com/bcoin-org/bsock.git",
           "requires": {
+            "bsert": "~0.0.3",
             "faye-websocket": "~0.11.1"
           }
         }
@@ -3436,6 +3425,14 @@
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
       }
     },
     "date-fns": {
@@ -4910,17 +4907,6 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
-    "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -4958,17 +4944,6 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
-    "fs-extra": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0"
-      }
-    },
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -5002,21 +4977,25 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "optional": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -5025,11 +5004,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5037,29 +5018,35 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "optional": true,
           "requires": {
             "ms": "2.0.0"
@@ -5067,22 +5054,26 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -5090,12 +5081,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -5110,7 +5103,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -5123,12 +5117,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "optional": true,
           "requires": {
             "safer-buffer": "^2.1.0"
@@ -5136,7 +5132,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -5144,7 +5141,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
             "once": "^1.3.0",
@@ -5153,39 +5151,46 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5193,7 +5198,8 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -5201,19 +5207,22 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "optional": true,
           "requires": {
             "debug": "^2.1.2",
@@ -5223,7 +5232,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
+          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -5240,7 +5250,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
             "abbrev": "1",
@@ -5249,12 +5260,14 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -5263,7 +5276,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -5274,33 +5288,39 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -5309,17 +5329,20 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "optional": true,
           "requires": {
             "deep-extend": "^0.5.1",
@@ -5330,14 +5353,16 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -5351,7 +5376,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "optional": true,
           "requires": {
             "glob": "^7.0.5"
@@ -5359,36 +5385,43 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5397,7 +5430,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -5405,19 +5439,22 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "optional": true,
           "requires": {
             "chownr": "^1.0.1",
@@ -5431,12 +5468,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "optional": true,
           "requires": {
             "string-width": "^1.0.2"
@@ -5444,11 +5483,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
     },
@@ -5515,6 +5556,14 @@
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
       }
     },
     "github-from-package": {
@@ -5618,22 +5667,6 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
       "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
-    },
-    "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "dev": true,
-      "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
-      }
     },
     "has": {
       "version": "1.0.3",
@@ -5838,17 +5871,6 @@
         "eventemitter3": "^3.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -6541,15 +6563,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
-    "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -6560,6 +6573,14 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
       }
     },
     "jsx-ast-utils": {
@@ -8709,12 +8730,6 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
-    },
     "phantomjs-prebuilt": {
       "version": "2.1.16",
       "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
@@ -8732,6 +8747,26 @@
         "which": "^1.2.10"
       },
       "dependencies": {
+        "fs-extra": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+          "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
         "progress": {
           "version": "1.1.8",
           "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
@@ -11142,6 +11177,64 @@
         "tough-cookie": "~2.3.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.1.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+          "dev": true
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+          "dev": true
+        }
       }
     },
     "request-progress": {
@@ -11896,6 +11989,14 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
       }
     },
     "ssri": {
@@ -12755,6 +12856,14 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
       }
     },
     "vm-browserify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1536,9 +1536,9 @@
       "from": "github:bcoin-org/bcoin",
       "requires": {
         "bcfg": "~0.1.0",
-        "bclient": "~0.1.1",
-        "bcrypto": "~0.3.7",
-        "bdb": "~0.2.1",
+        "bclient": "~0.1.0",
+        "bcrypto": "~0.3.1",
+        "bdb": "~0.2.0",
         "bdns": "~0.1.0",
         "bevent": "~0.1.0",
         "bfile": "~0.1.0",
@@ -1558,7 +1558,7 @@
         "bufio": "~0.2.0",
         "bupnp": "~0.2.1",
         "bval": "~0.1.0",
-        "bweb": "~0.1.1",
+        "bweb": "~0.1.0",
         "mrmr": "~0.1.0",
         "n64": "~0.2.0"
       },
@@ -2269,7 +2269,6 @@
       "version": "github:bcoin-org/bsock#a8b996da6e30fd87bf97809f1ee63760cf594186",
       "from": "github:bcoin-org/bsock",
       "requires": {
-        "bsert": "~0.0.3",
         "faye-websocket": "~0.11.1"
       }
     },
@@ -2286,7 +2285,6 @@
           "version": "git+https://github.com/bcoin-org/bsock.git#a8b996da6e30fd87bf97809f1ee63760cf594186",
           "from": "git+https://github.com/bcoin-org/bsock.git",
           "requires": {
-            "bsert": "~0.0.3",
             "faye-websocket": "~0.11.1"
           }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1592,6 +1592,7 @@
         "tweetnacl": "^0.14.3"
       }
     },
+
     "bcrypto": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-0.3.7.tgz",

--- a/webapp/components/Panel.js
+++ b/webapp/components/Panel.js
@@ -7,7 +7,30 @@ import { getRouteProps } from '../plugins/plugins';
 export default class extends PureComponent {
   constructor(props) {
     super(props);
-    this.routes = [];
+    const { customChildren = [], paths } = props;
+    this.routes = customChildren.map(({ Component, metadata }) => {
+      const { name } = metadata;
+
+      const pathName = paths[name]; // will be a unique path from state
+      let path;
+
+      try {
+        if (!name) throw 'Must pass a name for custom Panels';
+        if (!pathName) {
+          path = encodeURI(name);
+        } else {
+          path = encodeURI(pathName);
+        }
+        return (
+          <Route
+            exact
+            path={`/${path}`}
+            key={`nav-${name}`}
+            render={() => this.childRoute(Component, name)} // using render so we can pass props
+          />
+        );
+      } catch (e) {}
+    });
   }
 
   static get displayName() {
@@ -32,33 +55,6 @@ export default class extends PureComponent {
     const routeProps = getRouteProps(name, this.props);
 
     return <Component {...routeProps} />;
-  }
-
-  UNSAFE_componentWillMount() {
-    const { customChildren = [], paths } = this.props;
-    this.routes = customChildren.map(({ Component, metadata }) => {
-      const { name } = metadata;
-
-      const pathName = paths[name]; // will be a unique from state
-      let path;
-
-      try {
-        if (!name) throw 'Must pass a name for custom Panels';
-        if (!pathName) {
-          path = encodeURI(name);
-        } else {
-          path = encodeURI(pathName);
-        }
-        return (
-          <Route
-            exact
-            path={`/${path}`}
-            key={`nav-${name}`}
-            render={() => this.childRoute(Component, name)} // using render so we can pass props
-          />
-        );
-      } catch (e) {}
-    });
   }
 
   render() {

--- a/webapp/components/Panel.js
+++ b/webapp/components/Panel.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { Route } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import { getRouteProps } from '../plugins/plugins';
@@ -23,10 +23,9 @@ export default class extends PureComponent {
         }
         return (
           <Route
-            exact
             path={`/${path}`}
             key={`nav-${name}`}
-            render={() => this.childRoute(Component, name)} // using render so we can pass props
+            render={pathProps => this.childRoute(Component, name, pathProps)} // using render so we can pass props
           />
         );
       } catch (e) {}
@@ -49,15 +48,19 @@ export default class extends PureComponent {
 
   // a method to create the routes
   // returns the view Component with props
-  childRoute(Component, name = '') {
+  childRoute(Component, name = '', pathProps) {
     // get props needed for each route
     // 'name' should correspond with the plugin name for each route
     const routeProps = getRouteProps(name, this.props);
 
-    return <Component {...routeProps} />;
+    return <Component {...routeProps} {...pathProps} />;
   }
 
   render() {
-    return <div>{this.routes}</div>;
+    return (
+      <div>
+        <Switch>{this.routes}</Switch>
+      </div>
+    );
   }
 }

--- a/webapp/components/Panel.js
+++ b/webapp/components/Panel.js
@@ -11,19 +11,16 @@ export default class extends PureComponent {
     this.routes = customChildren.map(({ Component, metadata }) => {
       const { name } = metadata;
 
-      const pathName = paths[name]; // will be a unique path from state
-      let path;
+      let pathName = paths[name]; // will be a unique path from state
 
       try {
         if (!name) throw 'Must pass a name for custom Panels';
         if (!pathName) {
-          path = encodeURI(name);
-        } else {
-          path = encodeURI(pathName);
+          pathName = encodeURI(name);
         }
         return (
           <Route
-            path={`/${path}`}
+            path={`/${pathName}`}
             key={`nav-${name}`}
             render={pathProps => this.childRoute(Component, name, pathProps)} // using render so we can pass props
           />

--- a/webapp/components/Sidebar.js
+++ b/webapp/components/Sidebar.js
@@ -72,9 +72,11 @@ class Sidebar extends PureComponent {
     } = this.props;
     return (
       sidebarNavItems
-        // filter out any plugins w/o sidebar property set to true
+        // filter out any plugins w/o sidebar or nav property set to true
         // or that is not a valid react element (custom sidebar components)
-        .filter(plugin => plugin.sidebar || React.isValidElement(plugin))
+        .filter(
+          plugin => plugin.sidebar || plugin.nav || React.isValidElement(plugin)
+        )
         // map through each parent item to create the sidebar nav element
         .map((plugin, index) => {
           // for a nav item that is already a react element
@@ -89,16 +91,7 @@ class Sidebar extends PureComponent {
           };
           sidebarItemProps.pathName = this.getPathName(sidebarItemProps);
           if (plugin.parent) {
-            // const parentIndex = sidebarNavItems.findIndex(
-            //   item => (item.name = plugin.parent)
-            // );
-            // const parent = sidebarNavItems[parentIndex];
-
             // if this sidebar item is a child then add appropriate props
-            // const parentPath = parent.pathName ? parent.pathName : parent.name;
-            // const pathName = sidebarItemProps.pathName
-            //   ? `${parentPath}/${sidebarItemProps.pathName}`
-            //   : `${parentPath}/${sidebarItemProps.name}`;
             sidebarItemProps.subItem = true;
           }
           return this.renderNavItem(plugin, {

--- a/webapp/components/Sidebar.js
+++ b/webapp/components/Sidebar.js
@@ -89,7 +89,7 @@ class Sidebar extends PureComponent {
 
           // sanitize out any forward slashes or non-uri safe symbols from pathName
           // unless it is an absolute URL leading with http
-          if (sidebarItemProps.pathName.indexOf('http') !== 0)
+          if (!/^(http)/.test(sidebarItemProps.pathName))
             sidebarItemProps.pathName = `${match.url}${
               sidebarItemProps.pathName
             }`;

--- a/webapp/components/Sidebar.js
+++ b/webapp/components/Sidebar.js
@@ -59,10 +59,6 @@ class Sidebar extends PureComponent {
     return React.createElement(SidebarNavItem, props);
   }
 
-  getPathName(itemProps) {
-    return itemProps.pathName ? itemProps.pathName : itemProps.name;
-  }
-
   renderSidebarItems() {
     const {
       sidebarNavItems,
@@ -89,7 +85,7 @@ class Sidebar extends PureComponent {
             pathname,
             ...pluginProps
           };
-          sidebarItemProps.pathName = this.getPathName(sidebarItemProps);
+
           if (plugin.parent) {
             // if this sidebar item is a child then add appropriate props
             sidebarItemProps.subItem = true;

--- a/webapp/config/pluginsConfig.js
+++ b/webapp/config/pluginsConfig.js
@@ -1,9 +1,5 @@
-export const localPlugins = ['footer-address', 'test-child'];
+export const localPlugins = ['footer-address'];
 
-export const plugins = [
-  '@bpanel/genesis-theme',
-  '@bpanel/bdark-theme',
-  '@bpanel/simple-mining'
-];
+export const plugins = ['@bpanel/genesis-theme'];
 
 export default { localPlugins, plugins };

--- a/webapp/config/themeConfig/themeVariables.js
+++ b/webapp/config/themeConfig/themeVariables.js
@@ -106,7 +106,7 @@ const headerHeight = 7;
 const footerHeight = 2;
 
 // Logo
-const logoUrl = logo;
+const logoUrl = `/${logo}`;
 
 const themeVariables = {
   // rawRem holds all the values that will be converted

--- a/webapp/containers/App/App.js
+++ b/webapp/containers/App/App.js
@@ -111,6 +111,9 @@ class App extends PureComponent {
 }
 
 const mapStateToProps = state => ({
+  // by default the sidebar items stay in an unsorted state in the
+  // redux store. Using the selector you can get them sorted (and
+  // it will only recalculate if there's been a change in the state)
   sidebarNavItems: nav.sortedSidebarItems(state),
   theme: state.theme
 });

--- a/webapp/containers/App/App.js
+++ b/webapp/containers/App/App.js
@@ -4,7 +4,12 @@ import { bindActionCreators } from 'redux';
 import { Route, Redirect } from 'react-router';
 
 import ThemeProvider from '../ThemeProvider';
-import { nodeActions, socketActions, themeActions } from '../../store/actions/';
+import {
+  nodeActions,
+  socketActions,
+  themeActions,
+  navActions
+} from '../../store/actions/';
 import Header from '../Header';
 import Footer from '../Footer';
 import Sidebar from '../Sidebar';
@@ -19,11 +24,13 @@ import 'bootstrap/dist/css/bootstrap-grid.min.css';
 class App extends PureComponent {
   constructor(props) {
     super(props);
+    props.loadSideNav();
   }
 
   static get propTypes() {
     return {
       children: PropTypes.node,
+      loadSideNav: PropTypes.func.isRequired,
       sidebarNavItems: pluginMetadata.sortedMetadataPropTypes,
       location: PropTypes.shape({
         pathname: PropTypes.string
@@ -120,6 +127,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => {
   const { getNodeInfo } = nodeActions;
+  const { loadSideNav } = navActions;
   const { connectSocket, disconnectSocket } = socketActions;
   const { updateTheme } = themeActions;
   const appLoaded = () => ({ type: 'APP_LOADED' });
@@ -127,6 +135,7 @@ const mapDispatchToProps = dispatch => {
     {
       appLoaded,
       getNodeInfo,
+      loadSideNav,
       connectSocket,
       disconnectSocket,
       updateTheme

--- a/webapp/containers/App/App.js
+++ b/webapp/containers/App/App.js
@@ -9,6 +9,7 @@ import Header from '../Header';
 import Footer from '../Footer';
 import Sidebar from '../Sidebar';
 import Panel from '../Panel';
+import { nav } from '../../store/selectors';
 import { pluginMetadata } from '../../store/propTypes';
 import { connect } from '../../plugins/plugins';
 
@@ -110,7 +111,7 @@ class App extends PureComponent {
 }
 
 const mapStateToProps = state => ({
-  sidebarNavItems: state.nav.sidebar,
+  sidebarNavItems: nav.sortedSidebarItems(state),
   theme: state.theme
 });
 

--- a/webapp/containers/App/App.js
+++ b/webapp/containers/App/App.js
@@ -70,7 +70,7 @@ class App extends PureComponent {
   }
 
   render() {
-    const { sortedPluginMeta, location, theme } = this.props;
+    const { sortedPluginMeta, location, theme, match } = this.props;
     return (
       <ThemeProvider theme={theme}>
         <div>
@@ -83,6 +83,7 @@ class App extends PureComponent {
                   sidebarNavItems={sortedPluginMeta}
                   location={location}
                   theme={theme}
+                  match={match}
                 />
               </div>
               <div className={`${theme.app.content} col-sm-8 col-lg-9`}>

--- a/webapp/containers/App/App.js
+++ b/webapp/containers/App/App.js
@@ -33,7 +33,13 @@ class App extends PureComponent {
       disconnectSocket: PropTypes.func.isRequired,
       getNodeInfo: PropTypes.func.isRequired,
       updateTheme: PropTypes.func.isRequired,
-      appLoaded: PropTypes.func.isRequired
+      appLoaded: PropTypes.func.isRequired,
+      match: PropTypes.shape({
+        isExact: PropTypes.bool,
+        path: PropTypes.string,
+        url: PropTypes.string,
+        params: PropTypes.object
+      }).isRequired
     };
   }
 
@@ -59,7 +65,7 @@ class App extends PureComponent {
   getHomePath() {
     const { sortedPluginMeta } = this.props;
     const panels = sortedPluginMeta.filter(
-      plugin => plugin.sidebar || React.isValidElement(plugin)
+      plugin => plugin.sidebar || plugin.nav || React.isValidElement(plugin)
     );
     const homePath = panels[0]
       ? panels[0].pathName
@@ -105,7 +111,7 @@ class App extends PureComponent {
 }
 
 const mapStateToProps = state => ({
-  sortedPluginMeta: plugins.metadataWithUniquePaths(state),
+  sortedPluginMeta: plugins.navItems(state),
   theme: state.theme
 });
 

--- a/webapp/containers/App/App.js
+++ b/webapp/containers/App/App.js
@@ -9,7 +9,6 @@ import Header from '../Header';
 import Footer from '../Footer';
 import Sidebar from '../Sidebar';
 import Panel from '../Panel';
-import { plugins } from '../../store/selectors';
 import { pluginMetadata } from '../../store/propTypes';
 import { connect } from '../../plugins/plugins';
 
@@ -24,7 +23,7 @@ class App extends PureComponent {
   static get propTypes() {
     return {
       children: PropTypes.node,
-      sortedPluginMeta: pluginMetadata.sortedMetadataPropTypes,
+      sidebarNavItems: pluginMetadata.sortedMetadataPropTypes,
       location: PropTypes.shape({
         pathname: PropTypes.string
       }),
@@ -63,8 +62,8 @@ class App extends PureComponent {
   }
 
   getHomePath() {
-    const { sortedPluginMeta } = this.props;
-    const panels = sortedPluginMeta.filter(
+    const { sidebarNavItems } = this.props;
+    const panels = sidebarNavItems.filter(
       plugin => plugin.sidebar || plugin.nav || React.isValidElement(plugin)
     );
     const homePath = panels[0]
@@ -76,7 +75,7 @@ class App extends PureComponent {
   }
 
   render() {
-    const { sortedPluginMeta, location, theme, match } = this.props;
+    const { sidebarNavItems, location, theme, match } = this.props;
     return (
       <ThemeProvider theme={theme}>
         <div>
@@ -86,7 +85,7 @@ class App extends PureComponent {
                 className={`${theme.app.sidebarContainer} col-sm-4 col-lg-3`}
               >
                 <Sidebar
-                  sidebarNavItems={sortedPluginMeta}
+                  sidebarNavItems={sidebarNavItems}
                   location={location}
                   theme={theme}
                   match={match}
@@ -111,7 +110,7 @@ class App extends PureComponent {
 }
 
 const mapStateToProps = state => ({
-  sortedPluginMeta: plugins.navItems(state),
+  sidebarNavItems: state.nav.sidebar,
   theme: state.theme
 });
 

--- a/webapp/containers/Panel.js
+++ b/webapp/containers/Panel.js
@@ -4,10 +4,10 @@ import { bindActionCreators } from 'redux';
 import { connect } from '../plugins/plugins';
 import Panel from '../components/Panel';
 import { socketActions } from '../store/actions';
-import { plugins } from '../store/selectors';
+import { nav } from '../store/selectors';
 
 const mapStateToProps = state => ({
-  paths: plugins.uniquePathsByName(state),
+  paths: nav.uniquePathsByName(state),
   theme: state.theme
 });
 

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -7,6 +7,6 @@
 <body>
 <div id="app"></div>
 
-<script src="./main.bundle.js.gz"></script>
+<script src="/main.bundle.js.gz"></script>
 </body>
 </html>

--- a/webapp/plugins/utils.js
+++ b/webapp/plugins/utils.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 // utilities for the plugin system modules
 import assert from 'assert';
 import semver from 'semver';
@@ -11,7 +12,6 @@ export const propsReducerCallback = (name, parentProps, ...fnArgs) => (
   try {
     props_ = decorator(parentProps, acc, ...fnArgs);
   } catch (err) {
-    //eslint-disable-next-line no-console
     console.error(
       'Plugin error',
       `${decorator._pluginName}: Error occurred in \`${name}\``,
@@ -21,7 +21,6 @@ export const propsReducerCallback = (name, parentProps, ...fnArgs) => (
   }
 
   if (!props_ || typeof props_ !== 'object') {
-    // eslint-disable-next-line no-console
     console.error(
       'Plugin error',
       `${
@@ -73,7 +72,10 @@ export const checkMetadata = metadata => {
   // if it doesn't, duplicate from `name`
   if (!displayName) updatedMeta.displayName = name;
   // encode pathName if it exists
-  if (pathName) updatedMeta.pathName = encodeURI(pathName);
+  if (pathName) {
+    assert(pathName !== '/', 'pathName should not be a single forward slash');
+    updatedMeta.pathName = pathName.replace(/^(\/)+/, '');
+  }
 
   return updatedMeta;
 };
@@ -134,8 +136,10 @@ export const moduleLoader = (config, modules = []) => {
           // doing recursive call if plugin has plugin bundle
           modules = moduleLoader(plugin.pluginConfig, modules);
       } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(`Plugin failure: ${e.message} \n`, plugin);
+        console.error(
+          `Plugin failure: In ${plugin.metadata.name}, ${e.message} \n`,
+          plugin
+        );
       }
     });
   }

--- a/webapp/store/actions/index.js
+++ b/webapp/store/actions/index.js
@@ -2,3 +2,4 @@ export { default as nodeActions } from './nodeActions';
 export { default as socketActions } from './socketActions';
 export { default as chainActions } from './chainActions';
 export { default as themeActions } from './themeActions';
+export { default as navActions } from './navActions';

--- a/webapp/store/actions/navActions.js
+++ b/webapp/store/actions/navActions.js
@@ -1,6 +1,4 @@
 import assert from 'assert';
-// import bio from 'bufio';
-// import { hash256 } from 'bvcrypto';
 import { helpers } from '@bpanel/bpanel-utils';
 import { ADD_SIDE_NAV, REMOVE_SIDE_NAV, SET_SIDE_NAV } from '../constants/nav';
 import { sortedNavItems } from '../selectors/nav';

--- a/webapp/store/actions/navActions.js
+++ b/webapp/store/actions/navActions.js
@@ -1,19 +1,60 @@
-import { ADD_SIDE_NAV, REMOVE_SIDE_NAV } from '../constants/nav';
 import assert from 'assert';
+// import bio from 'bufio';
+// import { hash256 } from 'bvcrypto';
+import { helpers } from '@bpanel/bpanel-utils';
+import { ADD_SIDE_NAV, REMOVE_SIDE_NAV, SET_SIDE_NAV } from '../constants/nav';
+import { sortedNavItems } from '../selectors/nav';
 
 export function addSideNav(metadata) {
   assert(metadata.name, 'nav items must include a name');
   const { pathName, name } = metadata;
+  // get hash for unique id
+  const hash = helpers.getHash(metadata);
+  const id = hash.slice(0, 6);
   metadata.pathName = pathName ? pathName : name;
   return {
     type: ADD_SIDE_NAV,
-    payload: { ...metadata, sidebar: true }
+    payload: { ...metadata, sidebar: true, id }
+  };
+}
+
+export function setSideNav(sideNav) {
+  return {
+    type: SET_SIDE_NAV,
+    payload: sideNav
+  };
+}
+
+export function loadSideNav() {
+  return (dispatch, getState) => {
+    const currentSideNav = getState().nav.sidebar;
+    // only load if there isn't already a sidebar nav
+    if (currentSideNav.length) return;
+
+    const pluginMetadata = getState().pluginMetadata;
+    let sideNav = sortedNavItems({ pluginMetadata });
+    // add unique id to each nav item
+    sideNav = sideNav.map(item => {
+      item.id = item.id ? item.id : helpers.getHash(item).slice(0, 6);
+      return item;
+    });
+    dispatch(setSideNav(sideNav));
   };
 }
 
 export function removeSideNav(metadata) {
+  if (!metadata.id || !metadata.name)
+    // eslint-disable-next-line no-console
+    console.warn('Must pass an id or name to delete nav item');
   return {
     type: REMOVE_SIDE_NAV,
     payload: metadata
   };
 }
+
+export default {
+  addSideNav,
+  setSideNav,
+  removeSideNav,
+  loadSideNav
+};

--- a/webapp/store/actions/navActions.js
+++ b/webapp/store/actions/navActions.js
@@ -1,0 +1,8 @@
+import { ADD_SIDE_NAV } from '../constants/nav';
+
+export function addSideNav(metadata) {
+  return {
+    type: ADD_SIDE_NAV,
+    payload: { ...metadata, sidebar: true }
+  };
+}

--- a/webapp/store/actions/navActions.js
+++ b/webapp/store/actions/navActions.js
@@ -1,6 +1,10 @@
 import { ADD_SIDE_NAV, REMOVE_SIDE_NAV } from '../constants/nav';
+import assert from 'assert';
 
 export function addSideNav(metadata) {
+  assert(metadata.name, 'nav items must include a name');
+  const { pathName, name } = metadata;
+  metadata.pathName = pathName ? pathName : name;
   return {
     type: ADD_SIDE_NAV,
     payload: { ...metadata, sidebar: true }

--- a/webapp/store/actions/navActions.js
+++ b/webapp/store/actions/navActions.js
@@ -1,8 +1,15 @@
-import { ADD_SIDE_NAV } from '../constants/nav';
+import { ADD_SIDE_NAV, REMOVE_SIDE_NAV } from '../constants/nav';
 
 export function addSideNav(metadata) {
   return {
     type: ADD_SIDE_NAV,
     payload: { ...metadata, sidebar: true }
+  };
+}
+
+export function removeSideNav(metadata) {
+  return {
+    type: REMOVE_SIDE_NAV,
+    payload: metadata
   };
 }

--- a/webapp/store/constants/nav.js
+++ b/webapp/store/constants/nav.js
@@ -1,2 +1,3 @@
 export const ADD_SIDE_NAV = 'ADD_SIDE_NAV';
 export const REMOVE_SIDE_NAV = 'REMOVE_SIDE_NAV';
+export const SET_SIDE_NAV = 'SET_SIDE_NAV';

--- a/webapp/store/constants/nav.js
+++ b/webapp/store/constants/nav.js
@@ -1,1 +1,2 @@
 export const ADD_SIDE_NAV = 'ADD_SIDE_NAV';
+export const REMOVE_SIDE_NAV = 'REMOVE_SIDE_NAV';

--- a/webapp/store/constants/nav.js
+++ b/webapp/store/constants/nav.js
@@ -1,0 +1,1 @@
+export const ADD_SIDE_NAV = 'ADD_SIDE_NAV';

--- a/webapp/store/reducers/index.js
+++ b/webapp/store/reducers/index.js
@@ -3,3 +3,4 @@ export { default as pluginMetadata } from './pluginMetadata';
 export { default as chain } from './chain';
 export { default as theme } from './theme';
 export { default as wallets } from './wallets';
+export { default as nav } from './nav';

--- a/webapp/store/reducers/nav.js
+++ b/webapp/store/reducers/nav.js
@@ -1,11 +1,6 @@
 import { ADD_SIDE_NAV } from '../constants/nav';
 import { initialMetadata } from '../../plugins/plugins';
-import {
-  navItems,
-  sortPluginMetadata,
-  uniquePathNames,
-  getNestedPaths
-} from '../selectors/plugins';
+import { sortedNavItems } from '../selectors/nav';
 
 const pluginMetadata = initialMetadata();
 const initialState = {
@@ -18,11 +13,11 @@ const navStore = (state = initialState, action) => {
 
   switch (type) {
     case ADD_SIDE_NAV: {
-      let sidebar = newState.sidebar;
+      const sidebar = [...newState.sidebar];
       sidebar.push(payload);
-      sidebar = sortPluginMetadata(sidebar);
-      sidebar = getNestedPaths(sidebar);
-      sidebar = uniquePathNames(sidebar);
+      // sidebar = sortPluginMetadata(sidebar);
+      // sidebar = getNestedPaths(sidebar);
+      // sidebar = uniquePathNames(sidebar);
       newState.sidebar = sidebar;
       return newState;
     }
@@ -30,7 +25,7 @@ const navStore = (state = initialState, action) => {
     default:
       // default to nav from pluginMetadata
       if (!newState.sidebar.length)
-        newState.sidebar = navItems({ pluginMetadata });
+        newState.sidebar = sortedNavItems({ pluginMetadata });
       return newState;
   }
 };

--- a/webapp/store/reducers/nav.js
+++ b/webapp/store/reducers/nav.js
@@ -27,7 +27,7 @@ const navStore = (state = initialState, action) => {
       const index = sidebar.findIndex(
         item => item.name === payload.name || item.id === payload.id
       );
-      sidebar.splice(index, 1);
+      if (index > -1) sidebar.splice(index, 1);
       newState.sidebar = sidebar;
       return newState;
     }

--- a/webapp/store/reducers/nav.js
+++ b/webapp/store/reducers/nav.js
@@ -13,8 +13,8 @@ const navStore = (state = initialState, action) => {
 
   switch (type) {
     case ADD_SIDE_NAV: {
-      const sidebar = [...newState.sidebar];
-      sidebar.push(payload);
+      const sidebar = [...newState.sidebar, payload];
+      // sidebar.push(payload);
       newState.sidebar = sidebar;
       return newState;
     }

--- a/webapp/store/reducers/nav.js
+++ b/webapp/store/reducers/nav.js
@@ -1,4 +1,4 @@
-import { ADD_SIDE_NAV } from '../constants/nav';
+import { ADD_SIDE_NAV, REMOVE_SIDE_NAV } from '../constants/nav';
 import { initialMetadata } from '../../plugins/plugins';
 import { sortedNavItems } from '../selectors/nav';
 
@@ -15,9 +15,16 @@ const navStore = (state = initialState, action) => {
     case ADD_SIDE_NAV: {
       const sidebar = [...newState.sidebar];
       sidebar.push(payload);
-      // sidebar = sortPluginMetadata(sidebar);
-      // sidebar = getNestedPaths(sidebar);
-      // sidebar = uniquePathNames(sidebar);
+      newState.sidebar = sidebar;
+      return newState;
+    }
+
+    case REMOVE_SIDE_NAV: {
+      const sidebar = [...newState.sidebar];
+      const index = sidebar.findIndex(
+        item => item.name === payload.name || item.pathName === payload.pathName
+      );
+      sidebar.splice(index, 1);
       newState.sidebar = sidebar;
       return newState;
     }

--- a/webapp/store/reducers/nav.js
+++ b/webapp/store/reducers/nav.js
@@ -14,7 +14,6 @@ const navStore = (state = initialState, action) => {
   switch (type) {
     case ADD_SIDE_NAV: {
       const sidebar = [...newState.sidebar, payload];
-      // sidebar.push(payload);
       newState.sidebar = sidebar;
       return newState;
     }

--- a/webapp/store/reducers/nav.js
+++ b/webapp/store/reducers/nav.js
@@ -1,8 +1,5 @@
-import { ADD_SIDE_NAV, REMOVE_SIDE_NAV } from '../constants/nav';
-import { initialMetadata } from '../../plugins/plugins';
-import { sortedNavItems } from '../selectors/nav';
+import { ADD_SIDE_NAV, REMOVE_SIDE_NAV, SET_SIDE_NAV } from '../constants/nav';
 
-const pluginMetadata = initialMetadata();
 const initialState = {
   sidebar: []
 };
@@ -13,24 +10,34 @@ const navStore = (state = initialState, action) => {
 
   switch (type) {
     case ADD_SIDE_NAV: {
-      newState.sidebar = [...newState.sidebar, payload];
+      const duplicates = newState.sidebar.some(
+        nav => nav.name === payload.name || (!!nav.id && nav.id === payload.id)
+      );
+
+      if (duplicates)
+        // eslint-disable-next-line no-console
+        console.error(`Can't have duplicate names or ids for nav items`);
+      else newState.sidebar = [...newState.sidebar, payload];
+
       return newState;
     }
 
     case REMOVE_SIDE_NAV: {
       const sidebar = [...newState.sidebar];
       const index = sidebar.findIndex(
-        item => item.name === payload.name || item.pathName === payload.pathName
+        item => item.name === payload.name || item.id === payload.id
       );
       sidebar.splice(index, 1);
       newState.sidebar = sidebar;
       return newState;
     }
 
+    case SET_SIDE_NAV: {
+      if (!newState.sidebar.length) newState.sidebar = payload;
+      return newState;
+    }
+
     default:
-      // default to nav from pluginMetadata
-      if (!newState.sidebar.length)
-        newState.sidebar = sortedNavItems({ pluginMetadata });
       return newState;
   }
 };

--- a/webapp/store/reducers/nav.js
+++ b/webapp/store/reducers/nav.js
@@ -13,8 +13,7 @@ const navStore = (state = initialState, action) => {
 
   switch (type) {
     case ADD_SIDE_NAV: {
-      const sidebar = [...newState.sidebar, payload];
-      newState.sidebar = sidebar;
+      newState.sidebar = [...newState.sidebar, payload];
       return newState;
     }
 

--- a/webapp/store/reducers/nav.js
+++ b/webapp/store/reducers/nav.js
@@ -1,0 +1,38 @@
+import { ADD_SIDE_NAV } from '../constants/nav';
+import { initialMetadata } from '../../plugins/plugins';
+import {
+  navItems,
+  sortPluginMetadata,
+  uniquePathNames,
+  getNestedPaths
+} from '../selectors/plugins';
+
+const pluginMetadata = initialMetadata();
+const initialState = {
+  sidebar: []
+};
+
+const navStore = (state = initialState, action) => {
+  const newState = { ...state };
+  const { type, payload } = action;
+
+  switch (type) {
+    case ADD_SIDE_NAV: {
+      let sidebar = newState.sidebar;
+      sidebar.push(payload);
+      sidebar = sortPluginMetadata(sidebar);
+      sidebar = getNestedPaths(sidebar);
+      sidebar = uniquePathNames(sidebar);
+      newState.sidebar = sidebar;
+      return newState;
+    }
+
+    default:
+      // default to nav from pluginMetadata
+      if (!newState.sidebar.length)
+        newState.sidebar = navItems({ pluginMetadata });
+      return newState;
+  }
+};
+
+export default navStore;

--- a/webapp/store/reducers/pluginMetadata.js
+++ b/webapp/store/reducers/pluginMetadata.js
@@ -2,7 +2,6 @@ import { ADD_PLUGIN_META } from '../constants/plugins';
 import { initialMetadata } from '../../plugins/plugins';
 
 const initialPlugins = initialMetadata();
-
 const pluginMetadata = (state = initialPlugins, action) => {
   switch (action.type) {
     case ADD_PLUGIN_META: {

--- a/webapp/store/selectors/index.js
+++ b/webapp/store/selectors/index.js
@@ -1,1 +1,1 @@
-export { default as plugins } from './plugins';
+export { default as nav } from './nav';

--- a/webapp/store/selectors/nav.js
+++ b/webapp/store/selectors/nav.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { createSelector } from 'reselect';
 import { plugins } from '@bpanel/bpanel-utils';
 
+import { createUnique } from '../../utils/helpers';
 const { comparePlugins } = plugins;
 
 const getMetadataList = state => Object.values(state.pluginMetadata);
@@ -71,7 +72,7 @@ export function sanitizePaths(navItems) {
 export function getNestedPaths(metadata) {
   assert(Array.isArray(metadata), 'Must pass array of metadata');
   return metadata.reduce((updated, plugin) => {
-    if (plugin.parent && plugin.pathName.indexOf('http') !== 0) {
+    if (plugin.parent && !/^(http)/.test(plugin.pathName)) {
       // if this plugin is a child then update its pathName property
       // to nest behind the parent
       const parentIndex = metadata.findIndex(
@@ -113,17 +114,7 @@ export const getUniquePaths = metadata => {
     ({ paths, names, result }, plugin) => {
       const { pathName, name, displayName: _displayName } = plugin;
       if (pathName) {
-        let path = pathName;
-
-        if (paths.has(path)) {
-          // find unique suffix by incrementing counter
-          let counter = 1;
-          while (paths.has(`${path}-${counter}`)) {
-            counter++;
-          }
-          path = `${path}-${counter}`;
-        }
-
+        let path = createUnique(pathName, paths);
         paths.add(path);
         // set the metadata to the unique path
         plugin.pathName = path;
@@ -131,13 +122,8 @@ export const getUniquePaths = metadata => {
 
       // get unique displayName using same mechanism
       let displayName = _displayName ? _displayName : name;
-      if (names.has(displayName)) {
-        let counter = 1;
-        while (names.has(`${displayName}-${counter}`)) {
-          counter++;
-        }
-        displayName = `${displayName}-${counter}`;
-      }
+      displayName = createUnique(displayName, names);
+
       names.add(displayName);
       plugin.displayName = displayName;
 

--- a/webapp/store/selectors/nav.js
+++ b/webapp/store/selectors/nav.js
@@ -144,7 +144,8 @@ export function getNavItems(metadata = []) {
 // sort list of metadata -> compose nested paths -> make paths unique
 function composeNavItems(_navItems = []) {
   assert(Array.isArray(_navItems), 'Must pass array to composeNavItems');
-  let navItems = sortPluginMetadata(_navItems);
+  let navItems = getNavItems(_navItems);
+  navItems = sortPluginMetadata(navItems);
   navItems = getNestedPaths(navItems);
   navItems = getUniquePaths(navItems);
   return navItems;

--- a/webapp/tests/navSelector-test.js
+++ b/webapp/tests/navSelector-test.js
@@ -6,7 +6,7 @@ import {
   uniquePathNames,
   getNavItems,
   getNestedPaths
-} from '../store/selectors/plugins';
+} from '../store/selectors/nav';
 import { plugins } from '@bpanel/bpanel-utils';
 
 describe('plugin selectors', () => {
@@ -140,7 +140,7 @@ describe('plugin selectors', () => {
     let metadata;
 
     beforeEach(() => {
-      metadata = uniquePathNames(parentItems);
+      metadata = uniquePathNames(Object.values(parentItems));
     });
 
     it('should not have any metadata w/ duplicate pathNames or displayNames', () => {

--- a/webapp/tests/navSelector-test.js
+++ b/webapp/tests/navSelector-test.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 
 import {
   sortPluginMetadata,
-  uniquePathNames,
+  getUniquePaths,
   getNavItems,
   getNestedPaths
 } from '../store/selectors/nav';
@@ -136,11 +136,11 @@ describe('plugin selectors', () => {
     });
   });
 
-  describe('uniquePathNames', () => {
+  describe('getUniquePaths', () => {
     let metadata;
 
     beforeEach(() => {
-      metadata = uniquePathNames(Object.values(parentItems));
+      metadata = getUniquePaths(Object.values(parentItems));
     });
 
     it('should not have any metadata w/ duplicate pathNames or displayNames', () => {

--- a/webapp/tests/pluginsSelector-test.js
+++ b/webapp/tests/pluginsSelector-test.js
@@ -3,7 +3,9 @@ import sinon from 'sinon';
 
 import {
   sortPluginMetadata,
-  uniquePathNames
+  uniquePathNames,
+  getNavItems,
+  getNestedPaths
 } from '../store/selectors/plugins';
 import { plugins } from '@bpanel/bpanel-utils';
 
@@ -15,16 +17,19 @@ describe('plugin selectors', () => {
       'some wallet func': {
         name: 'some wallet func',
         order: 1,
+        nav: true,
         parent: 'wallets'
       },
       'first wallet func': {
         name: 'first wallet func',
         order: 0,
+        sidebar: true,
         parent: 'wallets'
       },
       'special-plugin': {
         name: 'special-plugin',
         order: 0,
+        nav: true,
         parent: 'xwallets'
       }
     };
@@ -40,16 +45,19 @@ describe('plugin selectors', () => {
         name: 'wallets',
         icon: 'hdd-o',
         pathName: 'wallets',
+        nav: true,
         order: 1
       },
       dashboard: {
         name: 'dashboard',
         order: 0,
+        nav: true,
         icon: 'home'
       },
       xwallets: {
         name: 'xwallets',
         icon: 'hdd-o',
+        sidebar: true,
         pathName: 'zwallets',
         order: 1
       }
@@ -164,6 +172,41 @@ describe('plugin selectors', () => {
             );
         })
       );
+    });
+  });
+
+  describe('getNavItems', () => {
+    it('should only have items with sidebar or nav properties set to true', () => {
+      const navItems = getNavItems(sortedPlugins);
+      assert(navItems.length, 'Data set did not return any nav items');
+      navItems.forEach(item =>
+        assert(
+          item.sidebar || item.nav,
+          `${item.name} does not have nav or sidebar property set to true`
+        )
+      );
+    });
+  });
+
+  describe('getNestedPaths', () => {
+    it('should update child pathNames to be nested if has a parent', () => {
+      const metadata = getNavItems(sortedPlugins);
+      const nested = getNestedPaths(metadata);
+      nested.forEach(plugin => {
+        if (plugin.parent) {
+          const parentIndex = metadata.findIndex(
+            item => item.name === plugin.parent
+          );
+
+          const parent = metadata[parentIndex];
+          const parentPath = parent.pathName ? parent.pathName : parent.name;
+
+          expect(
+            plugin.pathName === `${parentPath}/${plugin.pathName}`,
+            `${plugin.name} did not nest its path in its parent correctly`
+          );
+        }
+      });
     });
   });
 });

--- a/webapp/tests/pluginsSelector-test.js
+++ b/webapp/tests/pluginsSelector-test.js
@@ -10,7 +10,7 @@ import {
 import { plugins } from '@bpanel/bpanel-utils';
 
 describe('plugin selectors', () => {
-  let sortedPlugins, subItems, parentItems;
+  let sortedPlugins, subItems, parentItems, metadataList;
 
   beforeEach(() => {
     subItems = {
@@ -58,12 +58,14 @@ describe('plugin selectors', () => {
         name: 'xwallets',
         icon: 'hdd-o',
         sidebar: true,
+        displayName: 'zwallets',
         pathName: 'zwallets',
         order: 1
       }
     };
 
-    sortedPlugins = sortPluginMetadata({ ...parentItems, ...subItems });
+    metadataList = Object.values({ ...parentItems, ...subItems });
+    sortedPlugins = sortPluginMetadata(metadataList);
   });
 
   describe('sortPluginMetadata', () => {
@@ -75,7 +77,7 @@ describe('plugin selectors', () => {
 
     it('should call comparePlugins for sorting on parents and subItems', () => {
       const spy = sinon.spy(Array.prototype, 'sort');
-      sortPluginMetadata({ ...parentItems, ...subItems });
+      sortPluginMetadata(metadataList);
       expect(spy.calledWith(plugins.comparePlugins)).to.be.true;
       const parentNames = Object.keys(parentItems).sort();
       expect(parentNames[0]).to.equal(sortedPlugins[0].name);
@@ -141,37 +143,22 @@ describe('plugin selectors', () => {
       metadata = uniquePathNames(parentItems);
     });
 
-    it('should return plugins in sorted order', () => {
-      const sorted = sortPluginMetadata(parentItems);
-      metadata.forEach((plugin, index) =>
-        expect(plugin.name).to.equal(sorted[index].name)
-      );
-    });
-
-    it('should not have any metadata w/ duplicate pathNames', () => {
+    it('should not have any metadata w/ duplicate pathNames or displayNames', () => {
       const paths = new Set();
+      const names = new Set();
 
       metadata.forEach(plugin => {
         assert(
           !paths.has(plugin.pathName),
           `Found duplicate pathName: ${plugin.pathName}`
         );
+        assert(
+          !names.has(plugin.displayName),
+          `Found duplicate displayName: ${plugin.displayName}`
+        );
         paths.add(plugin.pathName);
+        names.add(plugin.displayName);
       });
-    });
-
-    it('should not have any name-pathName collisions between plugins', () => {
-      const paths = metadata.map(plugin => plugin.pathName);
-      const names = metadata.map(plugin => plugin.name);
-      paths.forEach((path, i) =>
-        names.forEach((name, j) => {
-          if (path === name)
-            assert(
-              i === j,
-              "plugin pathName should only collide with it's own name"
-            );
-        })
-      );
     });
   });
 

--- a/webapp/tests/utils-test.js
+++ b/webapp/tests/utils-test.js
@@ -128,13 +128,6 @@ describe('checkMetadata', () => {
     const test = checkMetadata({ name: testName });
     expect(test).to.deep.equal(expected);
   });
-
-  it('should make sure pathName is encoded for URI if set', () => {
-    const testPath = 'my path';
-    const expectedPath = encodeURI(testPath);
-    const test = checkMetadata({ name: 'test', pathName: testPath });
-    expect(test.pathName).to.equal(expectedPath);
-  });
 });
 
 describe('filterInternalProperties', () => {

--- a/webapp/tests/utilsHelpers-test.js
+++ b/webapp/tests/utilsHelpers-test.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+
+import { createUnique } from '../utils/helpers';
+
+describe('helpers', () => {
+  describe('createUnique', () => {
+    it('should return a copy of the same name if already unique', () => {
+      const names = new Set();
+      const original = 'test';
+
+      const name = createUnique(original, names);
+      expect(name).to.equal(original);
+    });
+
+    it('should increment name if already exists', () => {
+      const names = new Set();
+      const original = 'test';
+      names.add(original);
+      const test = createUnique(original, names);
+      names.add(test);
+      expect(test).to.equal(`${original}-1`);
+
+      const secondTest = createUnique(original, names);
+      expect(secondTest).to.equal(`${original}-2`);
+    });
+  });
+});

--- a/webapp/utils/helpers.js
+++ b/webapp/utils/helpers.js
@@ -1,0 +1,21 @@
+/* Given a Set
+ * @param {String} _name - name input to confirm if unique
+ * @param {Set} set - set of names to confirm if unique or not
+ * @returns {String} name - unique name given passed set of names
+ */
+export function createUnique(_name, set) {
+  let name = _name.slice();
+  if (set.has(name)) {
+    // find unique suffix by incrementing counter
+    let counter = 1;
+    while (set.has(`${name}-${counter}`)) {
+      counter++;
+    }
+    return `${name}-${counter}`;
+  }
+  return name;
+}
+
+export default {
+  createUnique
+};

--- a/webapp/utils/index.js
+++ b/webapp/utils/index.js
@@ -1,1 +1,2 @@
 export { default as createCss } from './createCss';
+export { default as helpers } from './helpers';


### PR DESCRIPTION
Support for hierarchal paths and for plugins to arbitrarily add new navigation items.

- [x] child paths and views through React Router's existing system
- [x] Composing plugin data for navigation
- [x] Navigation state in its own store
- [x] Mechanism for plugins to add new navigation and corresponding view/panel

**NOTE**: This uses the React Router's mechanisms for child paths. One strategy is via url-params (https://reacttraining.com/react-router/web/example/url-params) another is through the Switch component. These also lends itself well to plugins having to explicitly support sub-views in that they have to conditionally choose to show routes based on params. Will add an example here when ready. 

To test an example plugin that can add an arbitrary number of children views, I created a gist that you can add to your local install: https://gist.github.com/bucko13/62701b26eaed10f44d18c3fa0834ee8b 

I plan to create a utility HOC that will let developers bootstrap this functionality. That will be in either bpanel-utils or bpanel-ui.