### PR TITLE
deps: include bledger for plugins to use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -169,8 +169,11 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/@bpanel/bpanel-utils/-/bpanel-utils-0.0.10.tgz",
       "integrity": "sha512-cjpGxt8yuKeim218V6JeROW65bCSNA/BL/0U5FrkK33K/2YVXzIohz6/ulvlJNZyx95bXrJFs6QxbrmIMTftQQ==",
-      "requires": {
-        "brq": "git+https://github.com/bucko13/brq.git#a7e3aa59543d924d70ff582d516b2ee82586c590"
+      "dependencies": {
+        "brq": {
+          "version": "git+https://github.com/bucko13/brq.git#a7e3aa59543d924d70ff582d516b2ee82586c590",
+          "from": "git+https://github.com/bucko13/brq.git#a7e3aa59543d924d70ff582d516b2ee82586c590"
+        }
       }
     },
     "@sinonjs/formatio": {
@@ -1559,6 +1562,14 @@
             "bsert": "~0.0.3"
           }
         },
+        "bsock": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.2.tgz",
+          "integrity": "sha512-fWPIARHCdK76+cFdbEf46pBYCBtkXMDux4l1/T0AVmZNd7Z8jBlgTJnHZUm8KZ+wV287BSoX8lY1VcqvHjW8Dg==",
+          "requires": {
+            "bsert": "~0.0.3"
+          }
+        },
         "bweb": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/bweb/-/bweb-0.1.2.tgz",
@@ -1607,6 +1618,14 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.2.tgz",
           "integrity": "sha512-YE+G82KUl6HWScDfS3gGCxqGv4CsL+LI3K8oKtzZQVjvGu+LqgbRboT+6dCgXhaWRTTZXCaAsRdzK2tCemdcyw==",
+          "requires": {
+            "bsert": "~0.0.3"
+          }
+        },
+        "bsock": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.2.tgz",
+          "integrity": "sha512-fWPIARHCdK76+cFdbEf46pBYCBtkXMDux4l1/T0AVmZNd7Z8jBlgTJnHZUm8KZ+wV287BSoX8lY1VcqvHjW8Dg==",
           "requires": {
             "bsert": "~0.0.3"
           }
@@ -1710,6 +1729,47 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "bledger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bledger/-/bledger-0.1.1.tgz",
+      "integrity": "sha512-sfvhUzCdiA7fQG+FCz2IInNQTZK1r0cv3lb5pzkKflTlx/2jIViB2kpdpq0x06B+fmRFxtsIYNc1M3o/EtlFig==",
+      "requires": {
+        "bcrypto": "0.3.6",
+        "blgr": "^0.1.0",
+        "bmutex": "0.1.0",
+        "bufio": "0.2.0",
+        "node-hid": "^0.7.3",
+        "u2f-api": "^1.0.6"
+      },
+      "dependencies": {
+        "bcrypto": {
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-0.3.6.tgz",
+          "integrity": "sha512-G/yKm3MtlkVmDtUU2YjDfBnS7KUonW0cJzuxu/Mh7QaYUgzeobOTfCCesjNdNqlwSQzTzrxRVZYHUl6vTqCXnQ==",
+          "requires": {
+            "bindings": "~1.3.0",
+            "bn.js": "~4.11.8",
+            "bufio": "~0.2.0",
+            "elliptic": "~6.4.0",
+            "nan": "~2.10.0",
+            "secp256k1": "3.5.0"
+          }
+        },
+        "blgr": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.1.1.tgz",
+          "integrity": "sha512-paJmBPpsYYllidj7UvFvkrwtr2j6YLo7tmk0J885iY4Zw0ZFquV+OVtjDTpTOdeSFJefdi5URGrzOkrFm4M8QQ==",
+          "requires": {
+            "bsert": "~0.0.3"
+          }
+        },
+        "bmutex": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/bmutex/-/bmutex-0.1.0.tgz",
+          "integrity": "sha512-+r07Av637kDB5jU9Nexa0S8OxT0A8V/X9HOIMYAXxUJaDaDC7uwWwTaPR/DzlFlO6XtJ7hOcwXK1gasT5E+79g=="
+        }
+      }
+    },
     "blgr": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.0.2.tgz",
@@ -1748,7 +1808,6 @@
       "integrity": "sha512-0H+A9Wv7tn70dTLtslhkRm2q4RC9v2J1UYUT0wWD0gFt0fZYEG51KbbKyEs+tTVfEaWMbrv0HJA60AOuCl7NYA==",
       "requires": {
         "bclient": "~0.0.2",
-        "bcoin": "github:bcoin-org/bcoin#e093b2bdf68a554cb23694d39abe17ac7a3d0c23",
         "bcrypto": "~0.2.0",
         "bdb": "~0.1.0",
         "bevent": "0.0.2",
@@ -1784,7 +1843,7 @@
         },
         "bcoin": {
           "version": "github:bcoin-org/bcoin#e093b2bdf68a554cb23694d39abe17ac7a3d0c23",
-          "from": "github:bcoin-org/bcoin#e093b2b",
+          "from": "github:bcoin-org/bcoin#e093b2bdf68a554cb23694d39abe17ac7a3d0c23",
           "requires": {
             "bcfg": "~0.0.2",
             "bclient": "~0.0.2",
@@ -2226,10 +2285,6 @@
         "electron-to-chromium": "^1.3.30"
       }
     },
-    "brq": {
-      "version": "git+https://github.com/bucko13/brq.git#a7e3aa59543d924d70ff582d516b2ee82586c590",
-      "from": "git+https://github.com/bucko13/brq.git#body-bug"
-    },
     "bs32": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/bs32/-/bs32-0.1.1.tgz",
@@ -2257,8 +2312,7 @@
       "version": "github:bcoin-org/bsock#a8b996da6e30fd87bf97809f1ee63760cf594186",
       "from": "github:bcoin-org/bsock",
       "requires": {
-        "bsert": "~0.0.3",
-        "faye-websocket": "~0.11.1"
+        "bsert": "~0.0.3"
       }
     },
     "bsock-middleware": {
@@ -2266,13 +2320,12 @@
       "resolved": "https://registry.npmjs.org/bsock-middleware/-/bsock-middleware-1.1.3.tgz",
       "integrity": "sha512-mumRYB69UtOTDXrLlgeiCRmoIVM7z+BHFDAry7seueu0SFJxpdbZkehmebguzZw49UWVuQxw03yUTbkJOzwXMg==",
       "requires": {
-        "babel-polyfill": "^6.26.0",
-        "bsock": "git+https://github.com/bcoin-org/bsock.git#a8b996da6e30fd87bf97809f1ee63760cf594186"
+        "babel-polyfill": "^6.26.0"
       },
       "dependencies": {
         "bsock": {
           "version": "git+https://github.com/bcoin-org/bsock.git#a8b996da6e30fd87bf97809f1ee63760cf594186",
-          "from": "git+https://github.com/bcoin-org/bsock.git",
+          "from": "git+https://github.com/bcoin-org/bsock.git#a8b996da6e30fd87bf97809f1ee63760cf594186",
           "requires": {
             "bsert": "~0.0.3",
             "faye-websocket": "~0.11.1"
@@ -7815,6 +7868,16 @@
         "is-stream": "^1.0.1"
       }
     },
+    "node-hid": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/node-hid/-/node-hid-0.7.3.tgz",
+      "integrity": "sha512-LOCqWqcOlng+Kn1Qj/54zrPVfCagg1O7RlSgMmugykBcoYvUud6BswTrJM2aXuBac+bCCm3lA2srRG8YfmyXZQ==",
+      "requires": {
+        "bindings": "^1.3.0",
+        "nan": "^2.10.0",
+        "prebuild-install": "^4.0.0"
+      }
+    },
     "node-libs-browser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
@@ -12494,6 +12557,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz",
       "integrity": "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw="
+    },
+    "u2f-api": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/u2f-api/-/u2f-api-1.0.6.tgz",
+      "integrity": "sha512-CDvSoiHLdB4I7ArzAngsSattj7lIRBmih/NAD9VUKVuMBoQHuhDdIkEM80Fu2vAMUQO9WQc/kjF8Akp5JvVfQw=="
     },
     "ua-parser-js": {
       "version": "0.7.18",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "babel-runtime": "^6.26.0",
     "bclient": "^0.1.3",
     "bcoin": "bcoin-org/bcoin",
+    "bledger": "^0.1.1",
     "blgr": "0.0.2",
     "bmultisig": "^0.0.2",
     "body-parser": "^1.18.2",


### PR DESCRIPTION
Plugins that need to use `bledger` need to include it as a `peerDependency` so that `instanceof` checks do not fail when doing comparisons agains `bcoin.primitives` created outside of the library