### PR TITLE
move pluginsConfig to ~/.bpanel/.bpanel.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,16 @@ you want to use. `_docker` is the name of the config created by the bcoin
 service.
 
 ## Updating Plugins
+Plugin management is handled in a `js` file located in the `.bpanel` directory in your
+system's home directory.
+
 bPanel comes pre-installed with a default theme called [`Genesis Theme`](https://github.com/bpanel-org/genesis-theme),
 that bundles together a set of useful starter plugins and a custom skin called bMenace.
-If you want, you can disable the Genesis Theme by removing it from the list in `pluginsConfig.js`,
+If you want, you can disable the Genesis Theme by removing it from the list in `.bpanel.js`,
 but if you want to keep using _some_ of the plugins from the theme, feel free to add
 them individually to your config!
 
-To install plugins, simply add the name as a string to the `plugins` array in `webapp/plugins/pluginsConfig.js`.
+To install plugins, simply add the name as a string to the `plugins` array in `~/.bpanel/.bpanel.js`.
 Make sure to match the name to the package name on npm
 (`localPlugins` can be used for plugins you are developing in the `plugins/local` directory).
 Once you save the file, bPanel will automatically install the plugins and rebuild.

--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ system's home directory.
 
 bPanel comes pre-installed with a default theme called [`Genesis Theme`](https://github.com/bpanel-org/genesis-theme),
 that bundles together a set of useful starter plugins and a custom skin called bMenace.
-If you want, you can disable the Genesis Theme by removing it from the list in `.bpanel.js`,
+If you want, you can disable the Genesis Theme by removing it from the list in `config.js`,
 but if you want to keep using _some_ of the plugins from the theme, feel free to add
 them individually to your config!
 
-To install plugins, simply add the name as a string to the `plugins` array in `~/.bpanel/.bpanel.js`.
+To install plugins, simply add the name as a string to the `plugins` array in `~/.bpanel/config.js`.
 Make sure to match the name to the package name on npm
 (`localPlugins` can be used for plugins you are developing in the `plugins/local` directory).
 Once you save the file, bPanel will automatically install the plugins and rebuild.

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -3,10 +3,17 @@ const os = require('os');
 const path = require('path');
 
 const configsDir = path.resolve(os.homedir(), '.bpanel');
+const configsFile = path.resolve(configsDir, './.bpanel.js');
 const clientsDir = path.resolve(configsDir, 'clients');
 
+const configText = `module.exports = {
+  plugins: ['@bpanel/genesis-theme']
+  localPlugins: [],
+}`;
 if (!fs.existsSync(configsDir)) fs.mkdirSync(configsDir);
-
+if (!fs.existsSync(configsFile)) {
+  fs.appendFileSync(configsFile, configText);
+}
 if (!fs.existsSync(clientsDir)) fs.mkdirSync(clientsDir);
 
 require('./version.js');

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -3,11 +3,11 @@ const os = require('os');
 const path = require('path');
 
 const configsDir = path.resolve(os.homedir(), '.bpanel');
-const configsFile = path.resolve(configsDir, './.bpanel.js');
+const configsFile = path.resolve(configsDir, './config.js');
 const clientsDir = path.resolve(configsDir, 'clients');
 
 const configText = `module.exports = {
-  plugins: ['@bpanel/genesis-theme']
+  plugins: ['@bpanel/genesis-theme'],
   localPlugins: [],
 }`;
 if (!fs.existsSync(configsDir)) fs.mkdirSync(configsDir);

--- a/server/build-plugins.js
+++ b/server/build-plugins.js
@@ -8,7 +8,7 @@ const { execSync } = require('child_process');
 
 const logger = require('./logger');
 
-const pluginsConfig = resolve(os.homedir(), '.bpanel/.bpanel.js');
+const pluginsConfig = resolve(os.homedir(), '.bpanel/config.js');
 
 const { localPlugins, plugins } = require(pluginsConfig);
 

--- a/server/build-plugins.js
+++ b/server/build-plugins.js
@@ -1,16 +1,16 @@
 'use strict';
 
 const fs = require('fs');
-const logger = require('./logger');
+const os = require('os');
 const { resolve } = require('path');
 const { format } = require('prettier');
 const { execSync } = require('child_process');
-const { transformFileSync } = require('babel-core');
 
-const pluginsConfig = resolve(__dirname, '../webapp/config/pluginsConfig.js');
-const { localPlugins, plugins } = eval(
-  transformFileSync(pluginsConfig, { presets: 'env' }).code
-);
+const logger = require('./logger');
+
+const pluginsConfig = resolve(os.homedir(), '.bpanel/.bpanel.js');
+
+const { localPlugins, plugins } = require(pluginsConfig);
 
 const camelize = str =>
   str

--- a/server/build-plugins.js
+++ b/server/build-plugins.js
@@ -11,26 +11,6 @@ const logger = require('./logger');
 
 const pluginsConfig = resolve(os.homedir(), '.bpanel/config.js');
 
-// assert(
-//   fs.existsSync(pluginsConfig),
-//   'bPanel config file not found. Please run `npm install` before \
-// starting the server and building the app to automatically generate \
-// your config file.'
-// );
-// try {
-// } catch (e) {
-//   console.log(Object.keys(e))
-//   throw new Error(e.message);
-// }
-
-// if (!fs.existsSync(pluginsConfig)) {
-//   assert.error(
-//     'bPanel config file not found. Please run `npm install` before \
-// starting the server and building the app to automatically generate \
-// your config file.'
-//   );
-// }
-
 const camelize = str =>
   str
     // 1st deal w/ scoped packages (e.g. remove `@bpanel/`)

--- a/server/build-plugins.js
+++ b/server/build-plugins.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const os = require('os');
+const assert = require('assert');
 const { resolve } = require('path');
 const { format } = require('prettier');
 const { execSync } = require('child_process');
@@ -10,7 +11,25 @@ const logger = require('./logger');
 
 const pluginsConfig = resolve(os.homedir(), '.bpanel/config.js');
 
-const { localPlugins, plugins } = require(pluginsConfig);
+// assert(
+//   fs.existsSync(pluginsConfig),
+//   'bPanel config file not found. Please run `npm install` before \
+// starting the server and building the app to automatically generate \
+// your config file.'
+// );
+// try {
+// } catch (e) {
+//   console.log(Object.keys(e))
+//   throw new Error(e.message);
+// }
+
+// if (!fs.existsSync(pluginsConfig)) {
+//   assert.error(
+//     'bPanel config file not found. Please run `npm install` before \
+// starting the server and building the app to automatically generate \
+// your config file.'
+//   );
+// }
 
 const camelize = str =>
   str
@@ -95,9 +114,17 @@ const prepareModules = async (plugins = [], local = true) => {
 
 (async () => {
   try {
+    assert(
+      fs.existsSync(pluginsConfig),
+      'bPanel config file not found. Please run `npm install` before \
+starting the server and building the app to automatically generate \
+your config file.'
+    );
+
+    const { localPlugins, plugins } = require(pluginsConfig);
     prepareModules(localPlugins);
     await prepareModules(plugins, false);
   } catch (err) {
-    logger.error('There was an error preparing modules: ', err);
+    logger.error('There was an error preparing modules: ', err.stack);
   }
 })();

--- a/server/index.js
+++ b/server/index.js
@@ -71,7 +71,7 @@ module.exports = (_config = {}) => {
   const socketHandler = require('./bcoinSocket');
 
   // get bpanel config
-  const bpanelConfig = path.resolve(os.homedir(), '.bpanel/.bpanel.js');
+  const bpanelConfig = path.resolve(os.homedir(), '.bpanel/config.js');
 
   // Always start webpack
   require('nodemon')({

--- a/server/index.js
+++ b/server/index.js
@@ -54,20 +54,9 @@ if (require.main === module) {
 
 // Init bPanel
 module.exports = (_config = {}) => {
-  // Always start webpack
-  require('nodemon')({
-    script: './node_modules/.bin/webpack',
-    watch: ['webapp/config/pluginsConfig.js'],
-    args: webpackArgs,
-    legacyWatch: poll
-  })
-    .on('crash', () => {
-      process.exit(1);
-    })
-    .on('quit', process.exit);
-
   // Import server dependencies
   const path = require('path');
+  const os = require('os');
   const http = require('http');
   const express = require('express');
   const bsock = require('bsock').createServer();
@@ -80,6 +69,21 @@ module.exports = (_config = {}) => {
   const logger = require('./logger');
   const bcoinRouter = require('./bcoinRouter');
   const socketHandler = require('./bcoinSocket');
+
+  // get bpanel config
+  const bpanelConfig = path.resolve(os.homedir(), '.bpanel/.bpanel.js');
+
+  // Always start webpack
+  require('nodemon')({
+    script: './node_modules/.bin/webpack',
+    watch: [bpanelConfig],
+    args: webpackArgs,
+    legacyWatch: poll
+  })
+    .on('crash', () => {
+      process.exit(1);
+    })
+    .on('quit', process.exit);
 
   // Setting up configs
   // If passed a bcfg object we can just use that

--- a/webapp/config/pluginsConfig.js
+++ b/webapp/config/pluginsConfig.js
@@ -1,5 +1,0 @@
-export const localPlugins = ['footer-address'];
-
-export const plugins = ['@bpanel/genesis-theme'];
-
-export default { localPlugins, plugins };


### PR DESCRIPTION
I wanted to try and wrap moving localConfigs and a default theme configs setup into this PR but it's a little tough with the current architecture so probably better to put that off. This makes development much more convenient and having the config file outside makes more sense now that the client configs are also there. 