### PR TITLE
Load all client configs on the server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpanel/bpanel",
-  "version": "0.2.1-rc1",
+  "version": "0.2.2-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -146,9 +146,9 @@
           "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -772,9 +772,9 @@
       "dev": true
     },
     "atob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "autoprefixer": {
       "version": "7.2.6",
@@ -1765,50 +1765,38 @@
       }
     },
     "bcoin": {
-      "version": "github:bcoin-org/bcoin#ddeb73a39633213698ee18cf4e833b56b5488aeb",
+      "version": "github:bcoin-org/bcoin#0e799eb2dba7192b7d6fa347f538f74004042a61",
       "from": "github:bcoin-org/bcoin",
       "requires": {
-        "bcfg": "~0.1.0",
-        "bclient": "~0.1.1",
-        "bcrypto": "~0.3.7",
-        "bdb": "~0.2.1",
-        "bdns": "~0.1.0",
-        "bevent": "~0.1.0",
-        "bfile": "~0.1.0",
-        "bfilter": "~0.2.0",
-        "bheep": "~0.1.0",
-        "binet": "~0.3.0",
-        "blgr": "~0.1.0",
-        "blru": "~0.1.0",
-        "blst": "~0.1.0",
-        "bmutex": "~0.1.0",
-        "bn.js": "~4.11.8",
-        "bsip": "~0.1.0",
+        "bcfg": "~0.1.2",
+        "bclient": "~0.1.3",
+        "bcrypto": "~1.1.0",
+        "bdb": "~1.1.0",
+        "bdns": "~0.1.1",
+        "bevent": "~0.1.1",
+        "bfile": "~0.1.1",
+        "bfilter": "~1.0.0",
+        "bheep": "~0.1.1",
+        "binet": "~0.3.1",
+        "blgr": "~0.1.1",
+        "blru": "~0.1.2",
+        "blst": "~0.1.1",
+        "bmutex": "~0.1.2",
+        "bsert": "~0.0.4",
+        "bsip": "~0.1.1",
         "bsock": "~0.1.2",
-        "bsocks": "~0.2.0",
-        "bstring": "~0.1.0",
-        "btcp": "~0.1.0",
-        "bufio": "~0.2.0",
-        "bupnp": "~0.2.1",
-        "bval": "~0.1.0",
+        "bsocks": "~0.2.1",
+        "bstring": "~0.2.0",
+        "btcp": "~0.1.1",
+        "buffer-map": "~0.0.2",
+        "bufio": "~1.0.1",
+        "bupnp": "~0.2.2",
+        "bval": "~0.1.2",
         "bweb": "~0.1.3",
-        "mrmr": "~0.1.0",
-        "n64": "~0.2.0"
+        "mrmr": "~0.1.1",
+        "n64": "~0.2.1"
       },
       "dependencies": {
-        "bcrypto": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-0.3.7.tgz",
-          "integrity": "sha512-ZFeKszFo4abpbzLUK8sqQx87Np5ptaskhszU4Jf9JDFa1Bjuanwrv0a7z1xZJOWNG9abz8krgwvO1Z/NBtsgbg==",
-          "requires": {
-            "bindings": "~1.3.0",
-            "bn.js": "~4.11.8",
-            "bufio": "~0.2.0",
-            "elliptic": "~6.4.0",
-            "nan": "~2.10.0",
-            "secp256k1": "3.5.0"
-          }
-        },
         "blgr": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.1.1.tgz",
@@ -1816,11 +1804,6 @@
           "requires": {
             "bsert": "~0.0.3"
           }
-        },
-        "bufio": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/bufio/-/bufio-0.2.0.tgz",
-          "integrity": "sha512-PjL1QglhgZCWEKWbxzlVB4ExvNorHMu0JSu4ehzeKi38R74Fp7duHAl8xNEqsbJXP5Dfym7XuSEkVol1KX5mhw=="
         },
         "bweb": {
           "version": "0.1.3",
@@ -1844,17 +1827,14 @@
       }
     },
     "bcrypto": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-1.0.0.tgz",
-      "integrity": "sha512-oBqTLSr4VcjZKGMbw3IUjcllt9/zC/CZ//EwKt6RdVp9fLeV4rNalFqVJiNSMELSY7Y/Ftfo2rGCqmUzut4LHA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-1.1.0.tgz",
+      "integrity": "sha512-XOXwwnqnhH+9ASVHUtBP/tfzszHZ+TD5DMkER27OwF3wBUS8Rg/tnmfXRQ/h5hsrl5qPiTVtjsD6LjFvzgAIgw==",
       "requires": {
         "bindings": "~1.3.0",
-        "bn.js": "~4.11.8",
-        "bsert": "~0.0.3",
+        "bsert": "~0.0.4",
         "bufio": "~1.0.1",
-        "elliptic": "~6.4.0",
-        "nan": "~2.10.0",
-        "secp256k1": "3.5.0"
+        "nan": "~2.10.0"
       }
     },
     "bcurl": {
@@ -1868,12 +1848,13 @@
       }
     },
     "bdb": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/bdb/-/bdb-0.2.3.tgz",
-      "integrity": "sha512-GOfUit8Rq9Y5pUuD3N4zFdZ99sXfswj7QIoFyKQnqq0zmLeQ7riJcpReJZadluOWOmQovzNij75kgA/zlKRnsw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bdb/-/bdb-1.1.0.tgz",
+      "integrity": "sha512-+q1Mb0vvIAytag1HkA4eL6RRSlK3wKHpHHC5b/dHwSP0HMRb5rInvUY84vB6T+9wHnm88HWRiZyLPK4H4ICMVQ==",
       "requires": {
-        "bsert": "~0.0.3",
-        "leveldown": "4.0.1"
+        "bindings": "~1.3.0",
+        "bsert": "~0.0.4",
+        "nan": "~2.10.0"
       }
     },
     "bdns": {
@@ -1907,19 +1888,13 @@
       "integrity": "sha512-BzQX3loGHgVKfu4KhZ1lI3yaZeBSFar6kKBJNTBCtI+SvYhXn4OALgCxX0C0/9Ca39vjcSkwLhOLMZZGoC0F6g=="
     },
     "bfilter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/bfilter/-/bfilter-0.2.0.tgz",
-      "integrity": "sha512-kQ+LV1FTS3un6iiOqg9qp2kAF+fADZNMZpmv2DHMFIgRSCAjH4NHi9p9X3i34kGJlZzP7+KkySK5it/8/oWKEA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bfilter/-/bfilter-1.0.0.tgz",
+      "integrity": "sha512-K6Esl85WOlpj7EIiSPL5xjToTz1/rQ1SLrQpPpNUpOJLpvelka6JfvuEiWUyk7MuMPR7GqsDSVrnVDdJdwCJmg==",
       "requires": {
-        "bufio": "~0.2.0",
-        "mrmr": "~0.1.0"
-      },
-      "dependencies": {
-        "bufio": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/bufio/-/bufio-0.2.0.tgz",
-          "integrity": "sha512-PjL1QglhgZCWEKWbxzlVB4ExvNorHMu0JSu4ehzeKi38R74Fp7duHAl8xNEqsbJXP5Dfym7XuSEkVol1KX5mhw=="
-        }
+        "bsert": "~0.0.3",
+        "bufio": "~1.0.1",
+        "mrmr": "~0.1.1"
       }
     },
     "bheep": {
@@ -2078,6 +2053,29 @@
         "bweb": "~0.1.2"
       },
       "dependencies": {
+        "bcrypto": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-1.0.0.tgz",
+          "integrity": "sha512-oBqTLSr4VcjZKGMbw3IUjcllt9/zC/CZ//EwKt6RdVp9fLeV4rNalFqVJiNSMELSY7Y/Ftfo2rGCqmUzut4LHA==",
+          "requires": {
+            "bindings": "~1.3.0",
+            "bn.js": "~4.11.8",
+            "bsert": "~0.0.3",
+            "bufio": "~1.0.1",
+            "elliptic": "~6.4.0",
+            "nan": "~2.10.0",
+            "secp256k1": "3.5.0"
+          }
+        },
+        "bdb": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/bdb/-/bdb-0.2.3.tgz",
+          "integrity": "sha512-GOfUit8Rq9Y5pUuD3N4zFdZ99sXfswj7QIoFyKQnqq0zmLeQ7riJcpReJZadluOWOmQovzNij75kgA/zlKRnsw==",
+          "requires": {
+            "bsert": "~0.0.3",
+            "leveldown": "4.0.1"
+          }
+        },
         "blgr": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.1.1.tgz",
@@ -2090,6 +2088,16 @@
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.3.tgz",
           "integrity": "sha512-3MnMGtKFjqEXSzfQnABAhCGTCOpSjJuhmxACInJxGwfT2Yz1eXipHg1feVi1CGG0wVaYPrgCs6FLr+Y79adY1A=="
+        },
+        "bstring": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/bstring/-/bstring-0.1.1.tgz",
+          "integrity": "sha512-xpJd187BAzrW9DbXuttGhAnsPRZNfRuehYd1Qds7IGj64TISNtvXqlqqebRmOcpweGwkZiBGItNoMkGbF4Qomg==",
+          "requires": {
+            "bindings": "~1.3.0",
+            "bsert": "~0.0.3",
+            "nan": "~2.10.0"
+          }
         },
         "bweb": {
           "version": "0.1.3",
@@ -2211,9 +2219,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -2391,12 +2399,13 @@
       }
     },
     "bstring": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/bstring/-/bstring-0.1.1.tgz",
-      "integrity": "sha512-xpJd187BAzrW9DbXuttGhAnsPRZNfRuehYd1Qds7IGj64TISNtvXqlqqebRmOcpweGwkZiBGItNoMkGbF4Qomg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bstring/-/bstring-0.2.0.tgz",
+      "integrity": "sha512-lgmjJyuBT0wozjBU+aSYf9vvK5XtH2MxZDbMPqbNVl9n2QlloRg8cIh7QaDyUWZmCG9LhglWbsMU8gupPEhCCA==",
       "requires": {
         "bindings": "~1.3.0",
-        "bsert": "~0.0.3",
+        "bsert": "~0.0.4",
+        "n64": "~0.2.1",
         "nan": "~2.10.0"
       }
     },
@@ -2438,6 +2447,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "buffer-map": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-map/-/buffer-map-0.0.2.tgz",
+      "integrity": "sha512-7JXyu5/Y9uTodU0EDHHvSFmzNLecRbW9VNQF7YpAOU1Y0kcOYmXCVv26/UMhDH1M9qROeeYmAU8HQn8Cmc3KRw=="
     },
     "buffer-more-ints": {
       "version": "0.0.2",
@@ -2610,14 +2624,14 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000876",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000876.tgz",
-      "integrity": "sha512-HJRyA+FjkMz8ir9q0STdq50HpzYQjGFhasZZA67y5rd6CfOI3O7PZxe6IXcx8bZhMbvugkO30WyPq5QewmE8KQ=="
+      "version": "1.0.30000877",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000877.tgz",
+      "integrity": "sha512-9RcqvE8HYgdZZzFW6xBmj/CeCaTyCJdUhgkueBCq47AK//w/Yzlg0zcfV1GTlh3jyYEbresGfY2vDEG/AaK/dQ=="
     },
     "caniuse-lite": {
-      "version": "1.0.30000874",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000874.tgz",
-      "integrity": "sha512-29nr1EPiHwrJTAHHsEmTt2h+55L8j2GNFdAcYPlRy2NX6iFz7ZZiepVI7kP/QqlnHLq3KvfWpbmGa0d063U09w=="
+      "version": "1.0.30000877",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000877.tgz",
+      "integrity": "sha512-h04kV/lcuhItU1CZTJOxUEk/9R+1XeJqgc67E+XC8J9TjPM8kzVgOn27ZtRdDUo8O5F8U4QRCzDWJrVym3w3Cg=="
     },
     "capture-stack-trace": {
       "version": "1.0.0",
@@ -2699,9 +2713,9 @@
       "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
     },
     "ci-info": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.4.0.tgz",
+      "integrity": "sha512-Oqmw2pVfCl8sCL+1QgMywPfdxPJPkC51y4usw0iiE2S9qnEOAqXy8bwl1CpMpnoU39g4iKJTz6QZj+28FvOnjQ=="
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -3519,12 +3533,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "object-keys": "^1.0.12"
       }
     },
     "define-property": {
@@ -3784,9 +3797,9 @@
       "integrity": "sha512-Vlrbs//2bQTsFdOQixJXgTfCQ9BwOTXhlMV5AV/1lwDzqBtMSlpdHTLc7dkTbexs0ZyByR1SD6zQ+HmFJ2T3sw=="
     },
     "electron-to-chromium": {
-      "version": "1.3.57",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.57.tgz",
-      "integrity": "sha512-YYpZlr6mzR8cK5VRmTZydEt5Mp+WMg1/syrO40PoQzl76vJ+oQchL2d3FmEcWzw3FYqJVYJP/kYYSzTa7FLXwg=="
+      "version": "1.3.58",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.58.tgz",
+      "integrity": "sha512-AGJxlBEn2wOohxqWZkISVsOjZueKTQljfEODTDSEiMqSpH0S+xzV+/5oEM9AGaqhu7DzrpKOgU7ocQRjj0nJmg=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -3971,9 +3984,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.45",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
-      "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
+      "version": "0.10.46",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
+      "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.1",
@@ -4191,9 +4204,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -4201,9 +4214,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz",
-      "integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.10.0.tgz",
+      "integrity": "sha512-Mhl90VLucfBuhmcWBgbUNtgBiK955iCDK1+aHAz7QfDQF6wuzWZ6JjihZ3ejJoGlJWIuko7xLqNm8BA5uenKhA==",
       "requires": {
         "get-stdin": "^5.0.1"
       }
@@ -4279,9 +4292,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.13.0.tgz",
-      "integrity": "sha512-t6hGKQDMIt9N8R7vLepsYXgDfeuhp6ZJSgtrLEDxonpSubyxUZHjhm6LsAaZX8q6GYVxkbT3kTsV9G5mBCFR6A==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
+      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
       "requires": {
         "contains-path": "^0.1.0",
         "debug": "^2.6.8",
@@ -4331,10 +4344,11 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.10.0.tgz",
-      "integrity": "sha512-18rzWn4AtbSUxFKKM7aCVcj5LXOhOKdwBino3KKWy4psxfPW0YtIbE8WNRDUdyHFL50BeLb6qFd4vpvNYyp7hw==",
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
+      "integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
       "requires": {
+        "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
         "jsx-ast-utils": "^2.0.1",
@@ -4837,14 +4851,14 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
-          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
+          "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.1"
+            "uri-js": "^4.2.2"
           }
         },
         "ajv-keywords": {
@@ -4980,9 +4994,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.2.tgz",
-      "integrity": "sha512-kssLorP/9acIdpQ2udQVTiCS5LQmdEz9mvdIfDcl1gYX2tPKFADHSyFdvJS040XdFsPzemWtgI3q8mFVCxtX8A==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.5.tgz",
+      "integrity": "sha512-GHjtHDlY/ehslqv0Gr5N0PUJppgg/q0rOBvX0na1s7y1A3LWxPqCYU76s3Z1bM4+UZB4QF0usaXLT5wFpof5PA==",
       "dev": true,
       "requires": {
         "debug": "^3.1.0"
@@ -5017,11 +5031,6 @@
       "requires": {
         "for-in": "^1.0.1"
       }
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -6413,9 +6422,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -6505,11 +6514,11 @@
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.0.tgz",
+      "integrity": "sha512-plgvKjQtalH2P3Gytb7L61Lmz95g2DlpzFiQyRSFew8WoJKxtKRzrZMeyRN2supblm3Psc8OQGy7Xjb6XG11jw==",
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "^1.3.0"
       }
     },
     "is-data-descriptor": {
@@ -6613,9 +6622,9 @@
       "optional": true
     },
     "is-my-json-valid": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.18.0.tgz",
-      "integrity": "sha512-DWT87JHCSdCPCxbqBpS6Z2ajAt+MvrJq8I4xrpQljCvzODO5/fiquBp20a3sN6yCJvFbCRyYvJOHjpzkPTKJyA==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
+      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -6859,9 +6868,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -7689,9 +7698,9 @@
           "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -7962,9 +7971,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -8727,9 +8736,9 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "neo-async": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
-      "integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.2.tgz",
+      "integrity": "sha512-vdqTKI9GBIYcAEbFAcpKPErKINfPF5zIuz3/niBfq8WUZjpT2tytLlFVrBgWdOtqI4uaA/Rb6No0hux39XXDuw=="
     },
     "netmask": {
       "version": "1.0.6",
@@ -8744,9 +8753,9 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nise": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.2.tgz",
-      "integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.3.tgz",
+      "integrity": "sha512-cg44dkGHutAY+VmftgB1gHvLWxFl2vwYdF8WpbceYicQwylESRJiAAKgCRJntdoEbMiUzywkZEUzjoDWH0JwKA==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "^2.0.0",
@@ -9253,9 +9262,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -9952,9 +9961,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -10307,14 +10316,14 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
-          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
+          "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.1"
+            "uri-js": "^4.2.2"
           }
         },
         "ajv-keywords": {
@@ -11715,9 +11724,9 @@
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -11974,9 +11983,9 @@
       }
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -12134,9 +12143,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -12423,31 +12432,12 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-loader": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.3.tgz",
-      "integrity": "sha512-MYbFX9DYxmTQFfy2v8FC1XZwpwHKYxg3SK8Wb7VPBKuhDjz8gi9re2819MsG4p49HDyiOSUKlmZ+nQBArW5CGw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
+      "integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
       "requires": {
         "async": "^2.5.0",
-        "loader-utils": "~0.2.2",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "loader-utils": {
-          "version": "0.2.17",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0",
-            "object-assign": "^4.0.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
+        "loader-utils": "^1.1.0"
       }
     },
     "source-map-resolve": {
@@ -12840,9 +12830,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -13369,9 +13359,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -13547,9 +13537,9 @@
       "dev": true
     },
     "warning": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.1.tgz",
-      "integrity": "sha512-rAVtTNZw+cQPjvGp1ox0XC5Q2IBFyqoqh+QII4J/oguyu83Bax1apbo2eqB8bHRS+fqYUBagys6lqUoVwKSmXQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.2.tgz",
+      "integrity": "sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==",
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -13900,14 +13890,14 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
-          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
+          "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.1"
+            "uri-js": "^4.2.2"
           }
         },
         "ajv-keywords": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1765,7 +1765,7 @@
       }
     },
     "bcoin": {
-      "version": "github:bcoin-org/bcoin#eea4013dcfc2a8d944096bb4f07775b186ba4f9f",
+      "version": "github:bcoin-org/bcoin#ddeb73a39633213698ee18cf4e833b56b5488aeb",
       "from": "github:bcoin-org/bcoin",
       "requires": {
         "bcfg": "~0.1.0",

--- a/server/bcoinClients.js
+++ b/server/bcoinClients.js
@@ -6,7 +6,13 @@ const logger = require('./logger');
 const assert = require('assert');
 const Config = require('bcfg');
 
-module.exports = config => {
+/*
+ * Create clients based on given configs
+ * @param {Config} config - a bcfg config object
+ * @returns {Object} clients - an object that includes
+ * a Node, Wallet, and Multisig Wallet clients as available
+ */
+function clientFactory(config) {
   assert(
     config instanceof Config,
     'Must pass instance of Config class to client composer'
@@ -80,4 +86,6 @@ module.exports = config => {
   }
 
   return { nodeClient, walletClient, multisigWalletClient };
-};
+}
+
+module.exports = clientFactory;

--- a/server/index.js
+++ b/server/index.js
@@ -96,7 +96,9 @@ module.exports = (_config = {}) => {
   // env vars and config files using bcfg utilities in loadConfigs.js
   let config = _config;
   if (!(_config instanceof Config)) {
-    config = require('./loadConfigs')(_config);
+    config = require('./loadConfigs')(_config).find(
+      cfg => cfg.str('id') === bpanelConfig.str('client-id')
+    );
   }
 
   // create clients
@@ -134,8 +136,6 @@ module.exports = (_config = {}) => {
       logger.error('Error connecting sockets: ', err);
     }
 
-    // TODO: figure out if duplicating some events between
-    // the two different wallet clients
     bsock.on(
       'socket',
       socketHandler(nodeClient, walletClient, multisigWalletClient)

--- a/server/index.js
+++ b/server/index.js
@@ -74,7 +74,7 @@ module.exports = (_config = {}) => {
   const bpanelConfig = new Config('bpanel');
 
   // inject any custom configs passed
-  if (Object.keys(_config).length) bpanelConfig.inject(_config);
+  bpanelConfig.inject(_config);
 
   // load configs from environment
   bpanelConfig.load({ env: true, argv: true, arg: true });

--- a/server/loadConfigs.js
+++ b/server/loadConfigs.js
@@ -2,6 +2,21 @@ const Config = require('bcfg');
 const fs = require('fs');
 const { resolve } = require('path');
 
+// load main bpanel config
+function loadMainConfig(options = {}) {
+  const config = new Config('bpanel');
+  config.load({
+    env: true,
+    argv: true,
+    arg: true
+  });
+
+  // load any custom configs being passed in
+  config.inject(options);
+
+  return config;
+}
+
 /*
  * Get an array of configs for each client
  * in the module's home directory
@@ -10,15 +25,12 @@ const { resolve } = require('path');
  * @returns {Config[]} An array of Config object which can be
  * used to load clients
  */
-function loadConfigs(configs = {}) {
-  const config = new Config('bpanel');
-  config.load({
-    argv: true,
-    env: true
-  });
+function loadConfigs(_config) {
+  // first let's load the parent bpanel config
+  let config = _config;
 
-  // load any custom configs being passed in
-  config.inject(configs);
+  // if not passed bcfg object, create one
+  if (!(_config instanceof Config)) config = loadMainConfig(_config);
 
   // clientsDir is the folder where all client configs
   // should be saved and can be changed w/ custom configs
@@ -46,7 +58,7 @@ function loadConfigs(configs = {}) {
       // in the parent config's directory
       clientConf.inject({
         id: clientId,
-        prefix: `${config.prefix}/clients`
+        prefix: `${config.prefix}/${clientsDir}`
       });
 
       // can pass configs to clients via argv and env

--- a/server/loadConfigs.js
+++ b/server/loadConfigs.js
@@ -1,6 +1,7 @@
 const Config = require('bcfg');
 const fs = require('fs');
-const { resolve } = require('path');
+const assert = require('bsert');
+const { resolve, parse } = require('path');
 
 // load main bpanel config
 function loadMainConfig(options = {}) {
@@ -50,7 +51,8 @@ function loadConfigs(_config) {
       // After filter, we load bcfg object for each client
 
       // id is the file name without the extension
-      const clientId = fileName.slice(0, -5);
+      const { name: clientId, ext } = parse(fileName);
+      assert(ext === '.conf', 'client configs must have .conf extension');
       const clientConf = new Config(clientId);
 
       // set an id in the conf if not set

--- a/server/loadConfigs.js
+++ b/server/loadConfigs.js
@@ -1,11 +1,16 @@
 const Config = require('bcfg');
+const fs = require('fs');
+const { resolve } = require('path');
 
-function loadConfigs(configs) {
-  // Setup config object
-  // bPanel specific configs, will be prefixed with `BPANEL_` in env
-  // dataDir defaults to `~/.[MODULE_NAME]`, where MODULE_NAME
-  // is the first argument passed to the Config constructor
-  // (i.e. 'bpanel' below)
+/*
+ * Get an array of configs for each client
+ * in the module's home directory
+ * @param {Object} [configs] - Object of custom configs to inject
+ * into the bcfg config object
+ * @returns {Config[]} An array of Config object which can be
+ * used to load clients
+ */
+function loadConfigs(configs = {}) {
   const config = new Config('bpanel');
   config.load({
     argv: true,
@@ -15,15 +20,48 @@ function loadConfigs(configs) {
   // load any custom configs being passed in
   config.inject(configs);
 
-  // inject client configs from a config in the client dir
-  // pass `client-id` as a command line arg
-  // or as env var BPANEL_CLIENT_ID
-  // client dir is also configurable with `client-dir`
-  // or `BPANEL_CLIENT_DIR`
-  const clientDir = config.str('clients-dir', 'clients');
-  const clientId = config.str('client-id', 'default');
-  config.open(`${clientDir}/${clientId}.conf`);
-  return config;
+  // clientsDir is the folder where all client configs
+  // should be saved and can be changed w/ custom configs
+  const clientsDir = config.str('clients-dir', 'clients');
+
+  // get full path to client configs relative to the project
+  // prefix which defaults to `~/.bpanel`
+  const clientsPath = resolve(config.prefix, clientsDir);
+  const clientFiles = fs.readdirSync(clientsPath);
+
+  // ignore file names that start with a '.' such as
+  // system files and files without `.conf` extension
+  // then load config for that client
+  return clientFiles
+    .filter(name => name[0] !== '.' && /.conf$/.test(name))
+    .map(fileName => {
+      // After filter, we load bcfg object for each client
+
+      // id is the file name without the extension
+      const clientId = fileName.slice(0, -5);
+      const clientConf = new Config(clientId);
+
+      // set an id in the conf if not set
+      // prefix for the client config should be a clients dir
+      // in the parent config's directory
+      clientConf.inject({
+        id: clientId,
+        prefix: `${config.prefix}/clients`
+      });
+
+      // can pass configs to clients via argv and env
+      // will be the same for each config returned
+      clientConf.load({
+        argv: true,
+        env: true
+      });
+
+      // load configs from config file
+      // files are loaded from the prefix directory
+      clientConf.open(fileName);
+
+      return clientConf;
+    });
 }
 
 module.exports = loadConfigs;


### PR DESCRIPTION
This is the first step towards adding multi-network support. All this PR does is update loadConfigs so that it returns a config object for _each_ client config. It maintains existing functionality by picking out the config with a matching id to the `client-id` arg.

PR also adds docstrings and comments.

Later PRs will extend this into ability for clients to send requests for all clients simultaneously. 

