### PR TITLE
add error handler for redux middleware

### DIFF
--- a/webapp/store/index.js
+++ b/webapp/store/index.js
@@ -16,6 +16,24 @@ import {
 } from '../plugins/plugins';
 import * as reducers from './reducers';
 
+function errorCatcherMiddleware(errorHandler) {
+  return function(store) {
+    return function(next) {
+      return function(action) {
+        try {
+          return next(action);
+        } catch (err) {
+          const message = `There was an error in the middleware for the action ${
+            action.type
+          }: `;
+          errorHandler(message, err, store.getState, action, store.dispatch);
+          return err;
+        }
+      };
+    };
+  };
+}
+
 export default async () => {
   // load plugin information before setting up app and store
   await loadPlugins(config);
@@ -39,7 +57,13 @@ export default async () => {
 
   const persistedReducer = persistReducer(rootPersistConfig, rootReducer);
 
-  const middleware = [thunkMiddleware, pluginMiddleware, effects];
+  const middleware = [
+    // eslint-disable-next-line no-console
+    errorCatcherMiddleware(console.error),
+    thunkMiddleware,
+    pluginMiddleware,
+    effects
+  ];
   let compose,
     debug = false;
 


### PR DESCRIPTION
This is a simple update that allows us to catch and report errors properly that happen in the redux middleware chain.

Background:
I was having a hell of a time debugging something that looked like a socket error but was actually a problem happening during a dispatch. Because the dispatch was being sent by bsock-middleware the action creator that was running into the bug threw an error that bubbled up but was never caught. bsock-middleware saw this as a socket error (still not entirely clear on why this looked like `socket.error('on')`) and was sending an error back to the server making it very confusing to debug since the socket on the server was reporting it. 

This update makes sure middleware errors are properly caught and reported as middleware errors.

For reference, the error I was getting was when running bpanel against a handshake node. The `block connect` event was sending the block data but the recent-blocks plugin did not know how to decode the tx data (or block data for that matter). Since the encoding is different for handshake txs and blocks, bcoin.TX.fromRaw was failing. This bubbled up and got sent back to the server rather than throwing on the client side (it also threw in the browser but reported it as a bsock error). 

ASIDE
This brings up something else we'll have to think about which is how to allow for different plugins that could work for both blockchains but will need different utilities like `TX.fromRaw`. The simplest solution will be to just have plugin devs explicitly say which networks their plugins can work for and disable when not connecting to those. This makes sense for something like a naming plugin, but for something like a simple block explorer it would be nice if they worked for both. We could consider doing something like we have for bpanelClient, with a global primitives library that depends on what network the app has set to default. So when in "handshake" mode it would use `hsd` primitives, in "bitcoin" mode use `bcoin`, and for "bitcoincash" use `bcash`.