### PR TITLE
bugfix: use proper config to control https serving

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -225,12 +225,12 @@ module.exports = (_config = {}) => {
         });
 
       // can serve over https
-      if (bpanelConfig.bool('https', false)) {
+      if (bpanelConfig.bool('ssl', false)) {
         const fs = require('fs');
         const https = require('https');
         const httpsPort = bpanelConfig.int('https-port', 5001);
-        const keyPath = bpanelConfig.str('tls-key', '/etc/ssl/key.pem');
-        const certPath = bpanelConfig.str('tls-cert', '/etc/ssl/cert.pem');
+        const keyPath = bpanelConfig.str('ssl-key', '/etc/ssl/key.pem');
+        const certPath = bpanelConfig.str('ssl-cert', '/etc/ssl/cert.pem');
 
         let opts = {};
         try {

--- a/server/index.js
+++ b/server/index.js
@@ -225,12 +225,12 @@ module.exports = (_config = {}) => {
         });
 
       // can serve over https
-      if (clientConfig.bool('https', false)) {
+      if (bpanelConfig.bool('https', false)) {
         const fs = require('fs');
         const https = require('https');
-        const httpsPort = clientConfig.int('https-port', 5001);
-        const keyPath = clientConfig.str('tls-key', '/etc/ssl/key.pem');
-        const certPath = clientConfig.str('tls-cert', '/etc/ssl/cert.pem');
+        const httpsPort = bpanelConfig.int('https-port', 5001);
+        const keyPath = bpanelConfig.str('tls-key', '/etc/ssl/key.pem');
+        const certPath = bpanelConfig.str('tls-cert', '/etc/ssl/cert.pem');
 
         let opts = {};
         try {


### PR DESCRIPTION
Serving over https is a bpanel application setting, so this reverts to using the bpanel config object to pull the information from. It maintains the env var `BPANEL_HTTPS=true` to serve https