### PR TITLE
update row spacing

### DIFF
--- a/webapp/config/themeConfig/themeCreator.js
+++ b/webapp/config/themeConfig/themeCreator.js
@@ -404,8 +404,9 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
       dataRow: {
         display: 'flex',
         flexDirection: 'row',
-        marginBottom: '7px',
-        ...makeGutter('padding', { all: 0.33 })
+        alignItems: 'center',
+        ...makeGutter('margin', { bottom: 0.2 }),
+        ...makeGutter('padding', { right: 0.33, left: 0.33 })
       },
       borderedCol: {
         border: border2,


### PR DESCRIPTION
Minor styling tweaks. The recent blocks table was having its data pushed out of the expanded area so I thought it might be good to tighten up the rows a little bit. Unfortunately I don't have the tx table setup so couldn't test against that. 

Also centered the copy icon

Before:
<img width="1189" alt="screen shot 2018-08-23 at 5 31 14 pm" src="https://user-images.githubusercontent.com/4344978/44558791-083cbb00-a6fb-11e8-8f07-46dd72afc91d.png">

After:
<img width="1208" alt="screen shot 2018-08-23 at 5 32 00 pm" src="https://user-images.githubusercontent.com/4344978/44558794-0ecb3280-a6fb-11e8-9eab-68c248ae38a6.png">
