### PR TITLE
Fix auth bug with remote nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -255,20 +255,15 @@
       }
     },
     "@bpanel/bpanel-utils": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@bpanel/bpanel-utils/-/bpanel-utils-0.0.11.tgz",
-      "integrity": "sha512-DLxXft9XVSJKctG1gdkfUWDqEES3YCPU8GVDaKgAzokOj7sWaE8WlTGp46a/RrP59Rm1mmiC8IxYpx46zmOP8g==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@bpanel/bpanel-utils/-/bpanel-utils-0.0.12.tgz",
+      "integrity": "sha512-LvN3jdQjFt7riJ4emqoRlWmEFb/hNFiB+YdV3nIfOUowG3DzAJ41sMRjf2bjfrTJtlKXdfmSJ8obULHSasxYaA==",
       "requires": {
-        "bcrypto": "^1.0.0",
-        "bsert": "0.0.3",
-        "bufio": "^1.0.1"
-      },
-      "dependencies": {
-        "bsert": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.3.tgz",
-          "integrity": "sha512-3MnMGtKFjqEXSzfQnABAhCGTCOpSjJuhmxACInJxGwfT2Yz1eXipHg1feVi1CGG0wVaYPrgCs6FLr+Y79adY1A=="
-        }
+        "bcrypto": "^1.1.0",
+        "bcurl": "^0.1.2",
+        "bsert": "0.0.4",
+        "bufio": "^1.0.1",
+        "moment": "^2.22.2"
       }
     },
     "@emotion/babel-utils": {
@@ -2267,22 +2262,6 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
-    "bns": {
-      "version": "github:boymanjor/bns#9cdc726503e0776470d37f9fb5c294967f4014d7",
-      "from": "github:boymanjor/bns",
-      "requires": {
-        "bcrypto": "~1.1.0",
-        "bfile": "~0.1.1",
-        "bheep": "~0.1.1",
-        "binet": "~0.3.1",
-        "bs32": "~0.1.1",
-        "bsert": "~0.0.4",
-        "btcp": "~0.1.1",
-        "budp": "~0.1.1",
-        "bufio": "~1.0.1",
-        "unbound": "~0.1.0"
-      }
-    },
     "body-parser": {
       "version": "1.18.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
@@ -2536,13 +2515,12 @@
       "resolved": "https://registry.npmjs.org/bsock-middleware/-/bsock-middleware-1.1.3.tgz",
       "integrity": "sha512-mumRYB69UtOTDXrLlgeiCRmoIVM7z+BHFDAry7seueu0SFJxpdbZkehmebguzZw49UWVuQxw03yUTbkJOzwXMg==",
       "requires": {
-        "babel-polyfill": "^6.26.0",
-        "bsock": "git+https://github.com/bcoin-org/bsock.git#64539fac7296815d37fadf16b149f08efbc2ce08"
+        "babel-polyfill": "^6.26.0"
       },
       "dependencies": {
         "bsock": {
           "version": "git+https://github.com/bcoin-org/bsock.git#64539fac7296815d37fadf16b149f08efbc2ce08",
-          "from": "git+https://github.com/bcoin-org/bsock.git",
+          "from": "git+https://github.com/bcoin-org/bsock.git#64539fac7296815d37fadf16b149f08efbc2ce08",
           "requires": {
             "bsert": "~0.0.3"
           }
@@ -2573,11 +2551,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/btcp/-/btcp-0.1.1.tgz",
       "integrity": "sha512-EwqraaSVjrMYSuSchJ0t2gdeA/4BGgKu+tFVJpTpc4pjzrlu9O6kc3NNffSyIzoxd7jToRdrsT3TorA03a/qwQ=="
-    },
-    "budp": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/budp/-/budp-0.1.1.tgz",
-      "integrity": "sha512-qA+GZLvrD5CWKeprRjbOuQ5THn4v5wFdWlnuh17a5QK2BeDhU0Xthj1edS1yqpCIw/81cH/H8sq4injy8BJHZQ=="
     },
     "buffer": {
       "version": "4.9.1",
@@ -6326,7 +6299,6 @@
         "blru": "~0.1.2",
         "blst": "~0.1.1",
         "bmutex": "~0.1.2",
-        "bns": "github:boymanjor/bns#9cdc726503e0776470d37f9fb5c294967f4014d7",
         "bs32": "~0.1.1",
         "bsert": "~0.0.4",
         "bsip": "~0.1.1",
@@ -6351,6 +6323,22 @@
           "integrity": "sha512-paJmBPpsYYllidj7UvFvkrwtr2j6YLo7tmk0J885iY4Zw0ZFquV+OVtjDTpTOdeSFJefdi5URGrzOkrFm4M8QQ==",
           "requires": {
             "bsert": "~0.0.3"
+          }
+        },
+        "bns": {
+          "version": "github:boymanjor/bns#9cdc726503e0776470d37f9fb5c294967f4014d7",
+          "from": "github:boymanjor/bns#9cdc726503e0776470d37f9fb5c294967f4014d7",
+          "requires": {
+            "bcrypto": "~1.1.0",
+            "bfile": "~0.1.1",
+            "bheep": "~0.1.1",
+            "binet": "~0.3.1",
+            "bs32": "~0.1.1",
+            "bsert": "~0.0.4",
+            "btcp": "~0.1.1",
+            "budp": "~0.1.1",
+            "bufio": "~1.0.1",
+            "unbound": "~0.1.0"
           }
         },
         "bweb": {
@@ -8987,6 +8975,11 @@
           }
         }
       }
+    },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -13564,16 +13557,6 @@
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
-    },
-    "unbound": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/unbound/-/unbound-0.1.0.tgz",
-      "integrity": "sha512-PEF93iyiFyaCuQ7jSI5FxSzuS91A/vh6nAbKJNzMegpMYxf0PXflXs9SPL8C2KORkIwZwQA/ADgNVI/duVGPmA==",
-      "optional": true,
-      "requires": {
-        "bindings": "~1.3.0",
-        "nan": "~2.10.0"
-      }
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@bpanel/bpanel-ui": "^0.0.10",
-    "@bpanel/bpanel-utils": "^0.0.11",
+    "@bpanel/bpanel-utils": "^0.0.12",
     "aphrodite": "^1.2.5",
     "autoprefixer": "^7.1.5",
     "babel-cli": "^6.26.0",

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,4 +1,4 @@
-const fs = require('bfile');
+const fs = require('fs');
 const os = require('os');
 const path = require('path');
 

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -2,7 +2,7 @@
 // Looks at the git tags and sha to output the version.
 
 let commit, version;
-const fs = require('bfile');
+const fs = require('fs');
 const { execSync } = require('child_process');
 
 try {

--- a/server/clientFactory.js
+++ b/server/clientFactory.js
@@ -1,4 +1,4 @@
-const url = require('url');
+const { parse: urlParse } = require('url');
 const { Network: BNetwork } = require('bcoin');
 const { Network: HSNetwork } = require('hsd');
 const {
@@ -54,9 +54,9 @@ function clientFactory(config) {
   let hostname = config.str('node-host', '127.0.0.1');
   let protocol = config.str('protocol', 'http:');
 
-  let uri = config.str('node-uri');
-  if (uri) {
-    const nodeUrl = url.parse(uri);
+  let url = config.str('url') || config.str('node-uri');
+  if (url) {
+    const nodeUrl = urlParse(url);
     port = nodeUrl.port;
     hostname = nodeUrl.hostname;
     protocol = nodeUrl.protocol;
@@ -70,16 +70,17 @@ function clientFactory(config) {
     apiKey: config.str('api-key'),
     network: config.str('network', 'main'),
     port: config.uint('port'),
-    ssl: config.bool('ssl')
+    ssl: config.bool('ssl'),
+    url: config.str('url')
   };
 
   const walletOptions = {
     ...nodeOptions,
-    uri: config.str('wallet-uri'),
     apiKey: config.str('wallet-api-key', nodeOptions.apiKey),
     port: config.uint('wallet-port', network.walletPort),
     ssl: config.bool('wallet-ssl', nodeOptions.ssl),
-    token: config.str('wallet-token')
+    token: config.str('wallet-token'),
+    url: config.str('wallet-uri') || nodeOptions.url
   };
 
   let walletClient, nodeClient, multisigWalletClient;


### PR DESCRIPTION
Clients need to be set with a url param to avoid a bug that was happening when trying to subscribe to sockets for nodes not on the host machine. 

Also fixed a bug where a preinstall script required something (`bfile`) that needed to be installed... Switched it back to node's native `fs`