### PR TITLE
feature: add browser flag

### DIFF
--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -171,7 +171,9 @@ module.exports = function(env = {}) {
         }
       }),
       new webpack.DefinePlugin({
-        NODE_ENV: `"${process.env.NODE_ENV}"`
+        NODE_ENV: `"${process.env.NODE_ENV}"`,
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+        'process.env.BROWSER': JSON.stringify(true)
       })
     )
   };


### PR DESCRIPTION
Add `process.env.BROWSER` and set it to `true`, so that in plugins, developers can reference that value to determine to import node js or browser things. This is useful for the ledger/trezor stuff, as it differs whether its running in a browser or in nodejs