### PR TITLE
feature: configurable log level

### DIFF
--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -21,6 +21,9 @@ const {
 const bpanelPrefix =
   process.env.BPANEL_PREFIX || path.resolve(os.homedir(), '.bpanel');
 
+// default to debug log level, set to info in production config
+const logLevel = process.env.BPANEL_LOG_LEVEL || 'debug';
+
 module.exports = function(env = {}) {
   const plugins = [];
 
@@ -173,7 +176,8 @@ module.exports = function(env = {}) {
       new webpack.DefinePlugin({
         NODE_ENV: `"${process.env.NODE_ENV}"`,
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-        'process.env.BROWSER': JSON.stringify(true)
+        'process.env.BROWSER': JSON.stringify(true),
+        'process.env.LOG_LEVEL': JSON.stringify(logLevel)
       })
     )
   };

--- a/configs/webpack.prod.js
+++ b/configs/webpack.prod.js
@@ -64,6 +64,9 @@ module.exports = function(env = {}) {
         test: /\.js$/,
         algorithm: 'gzip',
         asset: '[path].gz[query]'
+      }),
+      new webpack.DefinePlugin({
+        'process.env.LOG_LEVEL': 'info'
       })
     ]
   });


### PR DESCRIPTION
This will set a `LOG_LEVEL` environment variable in webpack. This will be useful because `blgr` works on both the front end and the back end.

Wondering if there should be a differentiator between front end logging and back end logging.
Also, wondering if this should be done via the `Config` objects instead. It could be cleaner that way

The log level gets set to `info` for prod

I want to be able to access the `LOG_LEVEL` in my plugin