### PR TITLE
bugfix: works over tls

### DIFF
--- a/webapp/containers/App/App.js
+++ b/webapp/containers/App/App.js
@@ -9,7 +9,8 @@ import {
   nodeActions,
   socketActions,
   themeActions,
-  navActions
+  navActions,
+  appActions
 } from '../../store/actions/';
 import Header from '../Header';
 import Footer from '../Footer';
@@ -58,13 +59,16 @@ class App extends PureComponent {
 
   async componentDidMount() {
     const { getNodeInfo, connectSocket, hydrateClients } = this.props;
+
     await hydrateClients();
     connectSocket();
     getNodeInfo();
   }
 
   UNSAFE_componentWillMount() {
-    const { updateTheme, appLoaded } = this.props;
+    const { updateTheme, appLoaded, getWindowInfo } = this.props;
+
+    getWindowInfo();
     updateTheme();
     appLoaded();
   }
@@ -152,6 +156,7 @@ const mapDispatchToProps = dispatch => {
   const { connectSocket, disconnectSocket } = socketActions;
   const { updateTheme } = themeActions;
   const { hydrateClients } = clientActions;
+  const { getWindowInfo } = appActions;
   const appLoaded = () => ({ type: 'APP_LOADED' });
   return bindActionCreators(
     {
@@ -161,7 +166,8 @@ const mapDispatchToProps = dispatch => {
       loadSideNav,
       connectSocket,
       disconnectSocket,
-      updateTheme
+      updateTheme,
+      getWindowInfo
     },
     dispatch
   );

--- a/webapp/store/actions/appActions.js
+++ b/webapp/store/actions/appActions.js
@@ -1,0 +1,22 @@
+import * as types from '../constants/app';
+
+export function setWindowInfo(port, protocol, ssl) {
+  return {
+    type: types.SET_WINDOW,
+    payload: { port, protocol, ssl }
+  };
+}
+
+export function getWindowInfo() {
+  return dispatch => {
+    const port = Number(window.location.port);
+    const protocol = window.location.protocol;
+    let ssl = false;
+    if (protocol === 'https:') ssl = true;
+    dispatch(setWindowInfo(port, protocol, ssl));
+  };
+}
+
+export default {
+  getWindowInfo
+};

--- a/webapp/store/actions/index.js
+++ b/webapp/store/actions/index.js
@@ -1,3 +1,4 @@
+export { default as appActions } from './appActions';
 export { default as nodeActions } from './nodeActions';
 export { default as socketActions } from './socketActions';
 export { default as chainActions } from './chainActions';

--- a/webapp/store/actions/nodeActions.js
+++ b/webapp/store/actions/nodeActions.js
@@ -44,10 +44,14 @@ export function getNodeInfo() {
   };
 }
 
+// NOTE: this depends on the the app reducer
+// and having the port and ssl set first
 export function getServerInfo() {
-  return async dispatch => {
+  return async (dispatch, getState) => {
     try {
-      const client = bcurl.client({ port: 5000 });
+      const state = getState();
+      const { port, ssl } = state.app;
+      const client = bcurl.client({ port, ssl });
       const response = await client.get('server');
       dispatch(setBcoinUri(response.bcoinUri));
     } catch (e) {

--- a/webapp/store/constants/app.js
+++ b/webapp/store/constants/app.js
@@ -1,0 +1,1 @@
+export const SET_WINDOW = 'SET_WINDOW';

--- a/webapp/store/constants/index.js
+++ b/webapp/store/constants/index.js
@@ -4,8 +4,10 @@ import * as plugins from './plugins';
 import * as sockets from './sockets';
 import * as theme from './theme';
 import * as wallets from './wallets';
+import * as app from './app';
 
 export default {
+  app,
   chain,
   node,
   plugins,

--- a/webapp/store/reducers/app.js
+++ b/webapp/store/reducers/app.js
@@ -1,0 +1,26 @@
+import { SET_WINDOW } from '../constants/app';
+
+const initialState = {
+  port: null,
+  protocol: null,
+  ssl: null
+};
+
+const appState = (state = initialState, action) => {
+  let newState = { ...state };
+  const { type, payload = {} } = action;
+  switch (type) {
+    case SET_WINDOW: {
+      const { port, protocol, ssl } = payload;
+      newState.port = port;
+      newState.protocol = protocol;
+      newState.ssl = ssl;
+      return newState;
+    }
+
+    default:
+      return state;
+  }
+};
+
+export default appState;

--- a/webapp/store/reducers/index.js
+++ b/webapp/store/reducers/index.js
@@ -5,3 +5,4 @@ export { default as theme } from './theme';
 export { default as wallets } from './wallets';
 export { default as nav } from './nav';
 export { default as clients } from './clients';
+export { default as app } from './app';


### PR DESCRIPTION
Adds a new reducer and sets the `window.{port,protocol}` in the redux store, along with calculating `ssl`, which is required for `bcurl`