### PR TITLE
check for existence of client

### DIFF
--- a/server/clientFactory.js
+++ b/server/clientFactory.js
@@ -109,7 +109,9 @@ function clientFactory(config) {
   if (config.bool('wallet', true)) {
     walletClient = new WalletClient(walletOptions);
     logClientInfo(id, 'wallet', walletOptions);
+  }
 
+  if (config.bool('multisig', true)) {
     multisigWalletClient = new MultisigClient({
       ...walletOptions,
       multisigPath: '/'

--- a/server/clientRoutes.js
+++ b/server/clientRoutes.js
@@ -18,7 +18,10 @@ function clientsRouter(clients, defaultId) {
         `Client config ${id} had no chain set, defaulting to 'bitcoin'`
       );
     clientInfo[client.config.str('id')] = {
-      chain: client.config.str('chain', 'bitcoin')
+      chain: client.config.str('chain', 'bitcoin'),
+      hasNode: !!client.nodeClient,
+      hasWallet: !!client.walletClient,
+      hasMultisig: !!client.multisigWalletClient
     };
   });
   router.get('/', (req, res) => res.status(200).json(clientInfo));


### PR DESCRIPTION
This PR doesn't add a ton of information but addresses a previous request to know if a client is available. Just because there is a client, however, does not mean that the node in the backend can actually be connected to. Basically these properties only return false if a client config explicitly sets `node`, `wallet` or `multisig` to false.

I was thinking the `clientFactory` could do a check to see if the client was valid or not before saving it, but decided against for a couple reasons:

1) I think it would be worth thinking through the logic and expectations more around how to deal with an inaccessible node before just not including it at all
2) It's conceivable that a client can't reach a node w/ valid configuration at the time that the server is being started up and so we might still want to include it
3) It seems like it might be better to be able to report any connection errors back to the client for a user to debug, or at least be aware of, node connection errors. If we just don't include the client then you have to dig through server logs

So, this way, it's the user's responsibility to know the configs they are saving in the `clients` directory. When there is an interface for adding clients via the front end however, then I think it would be good to have a check to see if the node is reachable and then let the user decide whether or not to continue adding it. 