### PR TITLE
add support for user specified api keys in bpanel config directory

### DIFF
--- a/configs/webpack.common.config.js
+++ b/configs/webpack.common.config.js
@@ -13,11 +13,10 @@ const { MODULES_DIR, SRC_DIR, SERVER_DIR } = require('./constants');
 const bpanelPrefix =
   process.env.BPANEL_PREFIX || path.resolve(os.homedir(), '.bpanel');
 
-let MY_SECRETS = {};
-
 module.exports = () => {
+  let SECRETS = {};
   try {
-    MY_SECRETS = require(path.resolve(bpanelPrefix, 'secrets.json'));
+    SECRETS = require(path.resolve(bpanelPrefix, 'secrets.json'));
   } catch (e) {
     logger.error(
       `Couldn't find secrets.json in ${bpanelPrefix}. Make sure to run npm install to create boilerplate files`
@@ -66,7 +65,7 @@ module.exports = () => {
         }
       }),
       new webpack.DefinePlugin({
-        MY_SECRETS: JSON.stringify(MY_SECRETS),
+        SECRETS: JSON.stringify(SECRETS),
         NODE_ENV: `"${process.env.NODE_ENV}"`,
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         'process.env.BROWSER': JSON.stringify(true)

--- a/configs/webpack.common.config.js
+++ b/configs/webpack.common.config.js
@@ -1,7 +1,11 @@
 const path = require('path');
 const os = require('os');
+const webpack = require('webpack');
+const WebpackShellPlugin = require('webpack-synchronizable-shell-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-const { MODULES_DIR } = require('./constants');
+const logger = require('../server/logger');
+const { MODULES_DIR, SRC_DIR, SERVER_DIR } = require('./constants');
 
 // can be passed by server process via bcfg interface
 // or passed manually when running webpack from command line
@@ -9,28 +13,64 @@ const { MODULES_DIR } = require('./constants');
 const bpanelPrefix =
   process.env.BPANEL_PREFIX || path.resolve(os.homedir(), '.bpanel');
 
-module.exports = {
-  resolve: {
-    symlinks: false,
-    extensions: ['-browser.js', '.js', '.json', '.jsx'],
-    // list of aliases are what packages plugins can list as peerDeps
-    // this helps simplify plugin packages and ensures that parent classes
-    // all point to the same instance, e.g bcoin.TX will be same for all plugins
-    alias: {
-      bcoin$: `${MODULES_DIR}/bcoin/lib/bcoin-browser`,
-      bcash$: `${MODULES_DIR}/bcash/lib/bcoin-browser`,
-      hsd$: `${MODULES_DIR}/hsd/lib/hsd-browser`,
-      bledger: `${MODULES_DIR}/bledger/lib/bledger-browser`,
-      bmultisig: `${MODULES_DIR}/bmultisig/lib/bmultisig-browser`,
-      react: `${MODULES_DIR}/react`,
-      'react-router': `${MODULES_DIR}/react-router`,
-      'react-router-dom': `${MODULES_DIR}/react-router-dom`,
-      'react-redux': `${MODULES_DIR}/react-redux`,
-      'react-loadable': `${MODULES_DIR}/react-loadable`,
-      '&local': path.resolve(bpanelPrefix, 'local_plugins'),
-      '@bpanel/bpanel-utils': `${MODULES_DIR}/@bpanel/bpanel-utils`,
-      '@bpanel/bpanel-ui': `${MODULES_DIR}/@bpanel/bpanel-ui`,
-      tinycolor: 'tinycolor2'
-    }
+let MY_SECRETS = {};
+
+module.exports = () => {
+  try {
+    MY_SECRETS = require(path.resolve(bpanelPrefix, 'secrets.json'));
+  } catch (e) {
+    logger.error(
+      `Couldn't find secrets.json in ${bpanelPrefix}. Make sure to run npm install to create boilerplate files`
+    );
   }
+  return {
+    resolve: {
+      symlinks: false,
+      extensions: ['-browser.js', '.js', '.json', '.jsx'],
+      // list of aliases are what packages plugins can list as peerDeps
+      // this helps simplify plugin packages and ensures that parent classes
+      // all point to the same instance, e.g bcoin.TX will be same for all plugins
+      alias: {
+        bcoin$: `${MODULES_DIR}/bcoin/lib/bcoin-browser`,
+        bcash$: `${MODULES_DIR}/bcash/lib/bcoin-browser`,
+        hsd$: `${MODULES_DIR}/hsd/lib/hsd-browser`,
+        bledger: `${MODULES_DIR}/bledger/lib/bledger-browser`,
+        bmultisig: `${MODULES_DIR}/bmultisig/lib/bmultisig-browser`,
+        react: `${MODULES_DIR}/react`,
+        'react-router': `${MODULES_DIR}/react-router`,
+        'react-dom': `${MODULES_DIR}/react-dom`,
+        'react-router-dom': `${MODULES_DIR}/react-router-dom`,
+        'react-redux': `${MODULES_DIR}/react-redux`,
+        'react-loadable': `${MODULES_DIR}/react-loadable`,
+        '&local': path.resolve(bpanelPrefix, 'local_plugins'),
+        '@bpanel/bpanel-utils': `${MODULES_DIR}/@bpanel/bpanel-utils`,
+        '@bpanel/bpanel-ui': `${MODULES_DIR}/@bpanel/bpanel-ui`,
+        tinycolor: 'tinycolor2'
+      }
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        title: 'bPanel - A Blockchain Management System',
+        template: `${path.join(SRC_DIR, 'index.template.ejs')}`,
+        inject: 'body'
+      }),
+      new WebpackShellPlugin({
+        onBuildStart: {
+          scripts: [
+            `node ${path.resolve(SERVER_DIR, 'clear-plugins.js')}`,
+            `node ${path.resolve(
+              SERVER_DIR,
+              'build-plugins.js'
+            )} --prefix=${bpanelPrefix}`
+          ]
+        }
+      }),
+      new webpack.DefinePlugin({
+        MY_SECRETS: JSON.stringify(MY_SECRETS),
+        NODE_ENV: `"${process.env.NODE_ENV}"`,
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+        'process.env.BROWSER': JSON.stringify(true)
+      })
+    ]
+  };
 };

--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -4,18 +4,9 @@ const webpack = require('webpack');
 
 const merge = require('webpack-merge');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const WebpackShellPlugin = require('webpack-synchronizable-shell-plugin');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const config = require('./webpack.common.config.js');
-
-const {
-  ROOT_DIR,
-  DIST_DIR,
-  SRC_DIR,
-  SERVER_DIR,
-  MODULES_DIR
-} = require('./constants');
+const { ROOT_DIR, DIST_DIR, SRC_DIR, MODULES_DIR } = require('./constants');
 
 // can be passed by server process via bcfg interface
 // or passed manually when running webpack from command line
@@ -41,7 +32,7 @@ module.exports = function(env = {}) {
     console.error('There was an error building DllReferencePlugin:', e);
   }
 
-  return merge.smart(config, {
+  return merge.smart(config(), {
     context: ROOT_DIR,
     mode: 'development',
     optimization: {
@@ -125,30 +116,9 @@ module.exports = function(env = {}) {
       ]
     },
     plugins: plugins.concat(
-      new HtmlWebpackPlugin({
-        title: 'bPanel - A Blockchain Management System',
-        template: `${path.join(SRC_DIR, 'index.template.ejs')}`,
-        inject: 'body'
-      }),
       new MiniCssExtractPlugin({
         filename: '[name].css',
         chunkFilename: '[id].css'
-      }),
-      new WebpackShellPlugin({
-        onBuildStart: {
-          scripts: [
-            `node ${path.resolve(SERVER_DIR, 'clear-plugins.js')}`,
-            `node ${path.resolve(
-              SERVER_DIR,
-              'build-plugins.js'
-            )} --prefix=${bpanelPrefix}`
-          ]
-        }
-      }),
-      new webpack.DefinePlugin({
-        NODE_ENV: `"${process.env.NODE_ENV}"`,
-        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-        'process.env.BROWSER': JSON.stringify(true)
       })
     )
   });

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -8,6 +8,7 @@ const path = require('path');
 
 const BPANEL_DIR = path.resolve(os.homedir(), '.bpanel');
 const CONFIGS_FILE = path.resolve(BPANEL_DIR, './config.js');
+const SECRETS_FILE = path.resolve(BPANEL_DIR, './secrets.json');
 const CLIENTS_DIR = path.resolve(BPANEL_DIR, 'clients');
 const LOCAL_PLUGINS_DIR = path.resolve(BPANEL_DIR, 'local_plugins');
 
@@ -36,6 +37,13 @@ try {
       `info: No local plugins directory file found. Creating one at ${LOCAL_PLUGINS_DIR}`
     );
     fs.mkdirSync(LOCAL_PLUGINS_DIR);
+  }
+
+  if (!fs.existsSync(SECRETS_FILE)) {
+    console.log(
+      `info: No clients directory file found. Creating one at ${SECRETS_FILE}`
+    );
+    fs.appendFileSync(SECRETS_FILE, JSON.stringify({}));
   }
 
   if (!fs.existsSync(CLIENTS_DIR)) {


### PR DESCRIPTION
This update is needed for the [Peers Widget update.](https://github.com/bpanel-org/peers-widget/pull/4). This change also includes a re-arranging of the webpack configs so more of the common configs are actually in the common config file as well as an addition to the `preinstall` script to make sure to add a secrets.json file that webpack can access for personalized API keys.