### PR TITLE
Cleanup server

### DIFF
--- a/server/configHelpers.js
+++ b/server/configHelpers.js
@@ -7,7 +7,11 @@ const Config = require('bcfg');
 
 const logger = require('./logger');
 const clientFactory = require('./clientFactory');
-const { loadConfig, getConfigFromOptions } = require('./loadConfigs');
+const {
+  loadConfig,
+  getConfigFromOptions,
+  loadClientConfigs
+} = require('./loadConfigs');
 
 /*
  * create client config
@@ -165,6 +169,41 @@ async function testConfigOptions(options) {
   return [false, null];
 }
 
+/*
+ * Simple utility for getting a default config with logging
+ * for certain edge cases
+ * @param {Config} bpanelConfig
+ * @returns {Config}
+ */
+
+function getDefaultConfig(bpanelConfig) {
+  assert(
+    bpanelConfig instanceof Config,
+    'Need the main bcfg for the app to get default configs'
+  );
+  const clientConfigs = loadClientConfigs(bpanelConfig);
+  let defaultClientConfig = clientConfigs.find(
+    cfg => cfg.str('id') === bpanelConfig.str('client-id', 'default')
+  );
+
+  if (!defaultClientConfig) {
+    logger.error(
+      `Could not find config for ${bpanelConfig.str(
+        'client-id'
+      )}. Will set to 'default' instead.`
+    );
+    defaultClientConfig = clientConfigs.find(
+      cfg => cfg.str('id') === 'default'
+    );
+    if (!defaultClientConfig) {
+      logger.warn('Could not find default client config.');
+      defaultClientConfig = clientConfigs[0];
+      logger.warn(`Setting fallback to ${defaultClientConfig.str('id')}.`);
+    }
+  }
+  return defaultClientConfig;
+}
+
 class ClientErrors extends Error {
   constructor(...options) {
     super(...options);
@@ -189,6 +228,7 @@ class ClientErrors extends Error {
 
 module.exports = {
   createClientConfig,
+  getDefaultConfig,
   getConfig,
   deleteConfig,
   ClientErrors,

--- a/server/configHelpers.js
+++ b/server/configHelpers.js
@@ -162,7 +162,7 @@ async function testConfigOptions(options) {
     return [true, clientErrors];
   }
 
-  return [false];
+  return [false, null];
 }
 
 class ClientErrors extends Error {

--- a/server/index.js
+++ b/server/index.js
@@ -245,31 +245,10 @@ Visit the documentation for more information: https://bpanel.org/docs/configurat
       logger.debug(`Caught request in resolveIndex: ${req.path}`);
       res.sendFile(path.resolve(__dirname, '../dist/index.html'));
     };
+
     app.get('/', resolveIndex);
 
-    // route to get server info
-    const { ssl, host, port: clientPort } = nodeClient;
-
-    const uri = clientConfig.str(
-      'node-uri',
-      `${ssl ? 'https' : 'http'}://${host}:${clientPort}`
-    );
-    app.get('/server', (req, res) => res.status(200).send({ bcoinUri: uri }));
-
     app.use('/clients', clientRoutes(clients, clientId));
-
-    // redirects to support old routes
-    app.use('/bcoin', (req, res) =>
-      res.redirect(307, `/clients/${clientId}/node${req.path}`)
-    );
-
-    app.use('/bwallet', (req, res) =>
-      res.redirect(307, `/clients/${clientId}/wallet${req.path}`)
-    );
-
-    app.use('/multisig', (req, res) =>
-      res.redirect(307, `/clients/${clientId}/multisig${req.path}`)
-    );
 
     // TODO: add favicon.ico file
     app.get('/favicon.ico', (req, res) => {


### PR DESCRIPTION
To make these easily digestible, figured it might be easier review to put this up separately. this is just a cleanup PR. 
- Gets rid of deprecated endpoints (bcoin, bwallet, multisig) as these now are handled by `/clients`
- No longer sets the default `socket.io` socket subscription for a default as this is all done by id anyway
- Moves some config manipulation code out into the helpers file to help cleanup `server/index.js`