### PR TITLE
Socket proxy

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,9 @@ module.exports = {
         commonjs: true
       },
       globals: {
-        NODE_ENV: true
+        NODE_ENV: true,
+        BPANEL_SOCKET_PORT: true,
+        SECRETS: true
       }
     },
     {

--- a/configs/webpack.common.config.js
+++ b/configs/webpack.common.config.js
@@ -13,6 +13,10 @@ const { MODULES_DIR, SRC_DIR, SERVER_DIR } = require('./constants');
 const bpanelPrefix =
   process.env.BPANEL_PREFIX || path.resolve(os.homedir(), '.bpanel');
 
+// socket port hard coded in since running on a different port from
+// file server and http proxy
+const BPANEL_SOCKET_PORT = process.env.BPANEL_SOCKET_PORT || 8000;
+
 module.exports = () => {
   let SECRETS = {};
   try {
@@ -41,8 +45,6 @@ module.exports = () => {
         'react-redux': `${MODULES_DIR}/react-redux`,
         redux: `${MODULES_DIR}/redux`,
         'react-dom': `${MODULES_DIR}/react-dom`,
-        'react-router-dom': `${MODULES_DIR}/react-router-dom`,
-        'react-redux': `${MODULES_DIR}/react-redux`,
         'react-loadable': `${MODULES_DIR}/react-loadable`,
         '&local': path.resolve(bpanelPrefix, 'local_plugins'),
         '@bpanel/bpanel-utils': `${MODULES_DIR}/@bpanel/bpanel-utils`,
@@ -69,6 +71,7 @@ module.exports = () => {
       }),
       new webpack.DefinePlugin({
         SECRETS: JSON.stringify(SECRETS),
+        BPANEL_SOCKET_PORT: JSON.stringify(BPANEL_SOCKET_PORT),
         NODE_ENV: `"${process.env.NODE_ENV}"`,
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         'process.env.BROWSER': JSON.stringify(true)

--- a/package-lock.json
+++ b/package-lock.json
@@ -666,7 +666,7 @@
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
     },
     "ansi-regex": {
@@ -854,7 +854,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -1224,7 +1224,7 @@
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         }
@@ -2130,7 +2130,7 @@
       "dev": true
     },
     "bcash": {
-      "version": "github:bcoin-org/bcash#485a79dd61bd0e86ee64513c553a2723072e0c6e",
+      "version": "github:bcoin-org/bcash#a553951e92f07c0d0661bdad5320a390b8271304",
       "from": "github:bcoin-org/bcash",
       "requires": {
         "bcfg": "~0.1.3",
@@ -2151,7 +2151,7 @@
         "bsip": "~0.1.2",
         "bsock": "~0.1.3",
         "bsocks": "~0.2.2",
-        "bstring": "~0.3.2",
+        "bstring": "~0.3.0",
         "btcp": "~0.1.2",
         "buffer-map": "~0.0.3",
         "bufio": "~1.0.2",
@@ -2227,7 +2227,7 @@
       }
     },
     "bcoin": {
-      "version": "github:bcoin-org/bcoin#e305d900d61872c8a18e71476b50a57115fefd93",
+      "version": "github:bcoin-org/bcoin#fe340265c87a969ca6c862dfdd238d9f2d5883be",
       "from": "github:bcoin-org/bcoin",
       "requires": {
         "bcfg": "~0.1.3",
@@ -3026,7 +3026,7 @@
     },
     "cacache": {
       "version": "10.0.4",
-      "resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
       "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
       "dev": true,
       "requires": {
@@ -3476,7 +3476,7 @@
     },
     "colors": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "combine-lists": {
@@ -4648,7 +4648,7 @@
     },
     "d": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/d/-/d-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
       "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
       "dev": true,
       "requires": {
@@ -5101,7 +5101,7 @@
     },
     "engine.io-client": {
       "version": "3.2.1",
-      "resolved": "http://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
       "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
       "dev": true,
       "requires": {
@@ -5230,7 +5230,7 @@
       "dependencies": {
         "d": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true,
           "requires": {
@@ -5257,7 +5257,7 @@
       "dependencies": {
         "d": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true,
           "requires": {
@@ -5386,7 +5386,7 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },
@@ -5525,7 +5525,7 @@
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -5592,7 +5592,7 @@
     },
     "espree": {
       "version": "3.5.4",
-      "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
@@ -5651,7 +5651,7 @@
       "dependencies": {
         "d": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true,
           "requires": {
@@ -6295,7 +6295,7 @@
     },
     "fs-extra": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "dev": true,
       "requires": {
@@ -7724,7 +7724,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.1.0",
-          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
           "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
           "dev": true
         },
@@ -8271,7 +8271,7 @@
     },
     "jsesc": {
       "version": "0.5.0",
-      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
     },
     "json-parse-better-errors": {
@@ -8488,7 +8488,7 @@
     },
     "kew": {
       "version": "0.7.0",
-      "resolved": "http://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
       "dev": true
     },
@@ -8600,7 +8600,7 @@
       "dependencies": {
         "cosmiconfig": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
           "integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -9094,7 +9094,7 @@
       "dependencies": {
         "next-tick": {
           "version": "0.2.2",
-          "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
           "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0=",
           "dev": true
         }
@@ -9433,7 +9433,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
@@ -9942,7 +9942,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
@@ -9988,7 +9988,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -10182,7 +10182,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -12834,7 +12834,7 @@
     },
     "regjsgen": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
     },
     "regjsparser": {
@@ -12943,7 +12943,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -13121,7 +13121,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -13511,7 +13511,7 @@
     },
     "socket.io-parser": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "dev": true,
       "requires": {
@@ -13690,7 +13690,7 @@
     },
     "staged-git-files": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
       "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU="
     },
     "static-extend": {
@@ -13852,7 +13852,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
@@ -13882,7 +13882,7 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
         },
         "json-schema-traverse": {
@@ -14045,7 +14045,7 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },
@@ -15161,7 +15161,7 @@
       "dependencies": {
         "colors": {
           "version": "1.0.3",
-          "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
           "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
         }
       }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "bcoin": "bcoin-org/bcoin",
     "bcurl": "^0.1.3",
     "bfile": "^0.1.1",
+    "binet": "^0.3.2",
     "bledger": "^0.1.1",
     "blgr": "0.0.2",
     "bmultisig": "^1.0.1",

--- a/server/index.js
+++ b/server/index.js
@@ -98,9 +98,11 @@ module.exports = async (_config = {}) => {
   const express = require('express');
 
   // network information
-  const bcoinNetworks = require('bcash').protocol.networks;
-  const bcashNetworks = require('bcash').protocol.networks;
-  const hsdNetworks = require('hsd').protocol.networks;
+  const networks = {
+    bitcoin: require('bcoin/lib/protocol/networks'),
+    bitcoincash: require('bcash/lib/protocol/networks'),
+    handshake: require('hsd/lib/protocol/networks')
+  };
 
   // Import express middlewares
   const bodyParser = require('body-parser');
@@ -203,10 +205,11 @@ Visit the documentation for more information: https://bpanel.org/docs/configurat
     bpanelConfig.array('proxy-ports', [])
   );
 
-  for (let network of [bcoinNetworks, bcashNetworks, hsdNetworks]) {
-    ports.push(network.main.port);
-    ports.push(network.testnet.port);
+  for (let chain in networks) {
+    ports.push(networks[chain].main.port);
+    ports.push(networks[chain].testnet.port);
   }
+
   const socketManager = new SocketManager({
     noAuth: true,
     port: bsockPort,

--- a/server/index.js
+++ b/server/index.js
@@ -97,6 +97,11 @@ module.exports = async (_config = {}) => {
   const http = require('http');
   const express = require('express');
 
+  // network information
+  const bcoinNetworks = require('bcash').protocol.networks;
+  const bcashNetworks = require('bcash').protocol.networks;
+  const hsdNetworks = require('hsd').protocol.networks;
+
   // Import express middlewares
   const bodyParser = require('body-parser');
   const cors = require('cors');
@@ -191,10 +196,22 @@ Visit the documentation for more information: https://bpanel.org/docs/configurat
     level: 'info'
   });
   await blgr.open();
+
+  // setting up whitelisted ports for wsproxy
+  // can add other custom ones via `proxy-ports` config option
+  const ports = [18444, 28333, 28901].concat(
+    bpanelConfig.array('proxy-ports', [])
+  );
+
+  for (let network of [bcoinNetworks, bcashNetworks, hsdNetworks]) {
+    ports.push(network.main.port);
+    ports.push(network.testnet.port);
+  }
   const socketManager = new SocketManager({
     noAuth: true,
     port: bsockPort,
-    logger: blgr
+    logger: blgr,
+    ports
   });
 
   // Wait for async part of server setup

--- a/server/index.js
+++ b/server/index.js
@@ -150,12 +150,15 @@ will increase speed of future builds, so please be patient.'
     });
   }
 
+  const bsockPort = bpanelConfig.int('bsock-port') || 8000;
+
   // Always start webpack
   require('nodemon')({
     script: './node_modules/.bin/webpack',
     watch: [`${bpanelConfig.prefix}/config.js`],
     env: {
-      BPANEL_PREFIX: bpanelConfig.prefix
+      BPANEL_PREFIX: bpanelConfig.prefix,
+      BPANEL_SOCKET_PORT: bsockPort
     },
     args: webpackArgs,
     legacyWatch: poll
@@ -188,7 +191,6 @@ Visit the documentation for more information: https://bpanel.org/docs/configurat
   // Init app express server
   const app = express.Router();
   const port = process.env.PORT || 5000;
-  const bsockPort = process.env.BSOCK_PORT || 8000;
   app.use(bodyParser.json());
   app.use(cors());
 

--- a/webapp/store/actions/nodeActions.js
+++ b/webapp/store/actions/nodeActions.js
@@ -1,5 +1,4 @@
 import { getClient } from '@bpanel/bpanel-utils';
-import bcurl from 'bcurl';
 
 import * as types from '../constants/node';
 import { setChainInfo, getGenesisBlock } from './chainActions';

--- a/webapp/store/actions/socketActions.js
+++ b/webapp/store/actions/socketActions.js
@@ -4,13 +4,15 @@ import { getClient } from '@bpanel/bpanel-utils';
 const client = getClient();
 
 export function connectSocket() {
-  return {
-    type: CONNECT_SOCKET,
-    bsock: {
-      host: client.host ? client.host : 'localhost',
-      port: 8000,
-      namespace: client.id
-    }
+  return (dispatch, getState) => {
+    dispatch({
+      type: CONNECT_SOCKET,
+      bsock: {
+        host: client.host ? client.host : 'localhost',
+        port: getState().app.socketPort,
+        namespace: client.id
+      }
+    });
   };
 }
 

--- a/webapp/store/reducers/app.js
+++ b/webapp/store/reducers/app.js
@@ -3,7 +3,8 @@ import { SET_WINDOW } from '../constants/app';
 const initialState = {
   port: null,
   protocol: null,
-  ssl: null
+  ssl: null,
+  socketPort: 8000
 };
 
 const appState = (state = initialState, action) => {

--- a/webapp/store/reducers/app.js
+++ b/webapp/store/reducers/app.js
@@ -4,7 +4,7 @@ const initialState = {
   port: null,
   protocol: null,
   ssl: null,
-  socketPort: 8000
+  socketPort: parseInt(BPANEL_SOCKET_PORT, 10)
 };
 
 const appState = (state = initialState, action) => {


### PR DESCRIPTION
This adds backend support so that a node running in the browser can use the bpanel server's SocketManager to proxy tcp requests. Can be used with the new bpanel-utils utility [ProxySocket](https://github.com/bpanel-org/bpanel-utils/pull/33) which creates the socket client for the node to use to create a node from within the bPanel web app.

Both of these are almost exactly copy and pasted from the browser demo in bcoin. Tested with bcoin and bcash (hsd doesn't have in browser support quiet yet).