### PR TITLE
themeGenerator: add selectable row CSS

### DIFF
--- a/webapp/config/themeConfig/themeCreator.js
+++ b/webapp/config/themeConfig/themeCreator.js
@@ -10,8 +10,8 @@ const { makeRem, makeGutter } = utils;
 
 const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
   /* This if statement gives you access to default themeVariables in your custom theme.
-   ** Declaring your themeVariables as a function gives you access to the default themeVariables as
-   ** an argument to that function.
+   * Declaring your themeVariables as a function gives you access to the default themeVariables as
+   * an argument to that function.
    */
   if (typeof _themeVariables === 'function')
     _themeVariables = _themeVariables(themeVariables);
@@ -499,8 +499,8 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
   };
 
   /* This if statement gives you access to default themeConfig in your custom theme.
-   ** Declaring your themeConfig as a function gives you access to the default theme config as
-   ** an argument to that function.
+   * Declaring your themeConfig as a function gives you access to the default theme config as
+   * an argument to that function.
    */
   if (typeof _themeConfig === 'function')
     _themeConfig = _themeConfig(themeVariables, themeConfig);

--- a/webapp/config/themeConfig/themeCreator.js
+++ b/webapp/config/themeConfig/themeCreator.js
@@ -371,6 +371,9 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
       },
       selectedRow: {
         backgroundColor: themeColors.lowlight1
+      },
+      hoverExpandableRow: {
+        cursor: 'pointer'
       }
     },
 

--- a/webapp/config/themeConfig/themeCreator.js
+++ b/webapp/config/themeConfig/themeCreator.js
@@ -377,6 +377,11 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
         backgroundColor: themeColors.transparent,
         fontWeight: fontWeights.light
       },
+      expandableRow: {
+        ':hover': {
+          cursor: 'pointer'
+        }
+      },
       selectableRow: {
         ':hover': {
           cursor: 'pointer',

--- a/webapp/config/themeConfig/themeCreator.js
+++ b/webapp/config/themeConfig/themeCreator.js
@@ -365,37 +365,12 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
       body: {
         fontWeight: fontWeights.light
       },
-      headerRow: {
-        backgroundColor: themeColors.mediumBg,
-        fontWeight: fontWeights.light
-      },
-      oddRow: {
-        backgroundColor: themeColors.lightBg,
-        fontWeight: fontWeights.light
-      },
-      evenRow: {
-        backgroundColor: themeColors.transparent,
-        fontWeight: fontWeights.light
-      },
-      expandableRow: {
-        ':hover': {
-          cursor: 'pointer'
-        }
-      },
-      selectableRow: {
-        ':hover': {
-          cursor: 'pointer',
-          backgroundColor: themeColors.highlight1
-        }
+      hoverRow: {
+        cursor: 'pointer',
+        backgroundColor: themeColors.highlight1
       },
       selectedRow: {
-        ':hover': {
-          cursor: 'pointer'
-        },
         backgroundColor: themeColors.lowlight1
-      },
-      selectedRowIndicator: {
-        padding: '10px'
       }
     },
 
@@ -565,6 +540,7 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
     tabMenu: StyleSheet.create(tabMenu),
     text: StyleSheet.create(text),
     themeVariables: mergedThemeVariables,
+    themeConfig: mergedThemeConfig,
     logoUrl,
     tableRowStyle
   };

--- a/webapp/config/themeConfig/themeCreator.js
+++ b/webapp/config/themeConfig/themeCreator.js
@@ -367,10 +367,10 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
       },
       hoverRow: {
         cursor: 'pointer',
-        backgroundColor: themeColors.highlight1
+        backgroundColor: themeColors.highlight1 + ' !important'
       },
       selectedRow: {
-        backgroundColor: themeColors.lowlight1
+        backgroundColor: themeColors.lowlight1 + ' !important'
       },
       hoverExpandableRow: {
         cursor: 'pointer'
@@ -543,7 +543,6 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
     tabMenu: StyleSheet.create(tabMenu),
     text: StyleSheet.create(text),
     themeVariables: mergedThemeVariables,
-    themeConfig: mergedThemeConfig,
     logoUrl,
     tableRowStyle
   };

--- a/webapp/config/themeConfig/themeCreator.js
+++ b/webapp/config/themeConfig/themeCreator.js
@@ -367,8 +367,15 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
       },
       selectableRow: {
         ':hover': {
-          cursor: 'pointer'
+          cursor: 'pointer',
+          backgroundColor: themeColors.highlight1
         }
+      },
+      selectedRow: {
+        ':hover': {
+          cursor: 'pointer'
+        },
+        backgroundColor: themeColors.lowlight1
       },
       selectedRowIndicator: {
         padding: '10px'

--- a/webapp/config/themeConfig/themeCreator.js
+++ b/webapp/config/themeConfig/themeCreator.js
@@ -365,6 +365,18 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
       body: {
         fontWeight: fontWeights.light
       },
+      headerRow: {
+        backgroundColor: themeColors.mediumBg,
+        fontWeight: fontWeights.light
+      },
+      oddRow: {
+        backgroundColor: themeColors.lightBg,
+        fontWeight: fontWeights.light
+      },
+      evenRow: {
+        backgroundColor: themeColors.transparent,
+        fontWeight: fontWeights.light
+      },
       selectableRow: {
         ':hover': {
           cursor: 'pointer',

--- a/webapp/config/themeConfig/themeCreator.js
+++ b/webapp/config/themeConfig/themeCreator.js
@@ -10,9 +10,9 @@ const { makeRem, makeGutter } = utils;
 
 const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
   /* This if statement gives you access to default themeVariables in your custom theme.
-  ** Declaring your themeVariables as a function gives you access to the default themeVariables as
-  ** an argument to that function.
-  */
+   ** Declaring your themeVariables as a function gives you access to the default themeVariables as
+   ** an argument to that function.
+   */
   if (typeof _themeVariables === 'function')
     _themeVariables = _themeVariables(themeVariables);
 
@@ -364,6 +364,14 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
       },
       body: {
         fontWeight: fontWeights.light
+      },
+      selectableRow: {
+        ':hover': {
+          cursor: 'pointer'
+        }
+      },
+      selectedRowIndicator: {
+        padding: '10px'
       }
     },
 
@@ -491,9 +499,9 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
   };
 
   /* This if statement gives you access to default themeConfig in your custom theme.
-  ** Declaring your themeConfig as a function gives you access to the default theme config as
-  ** an argument to that function.
-  */
+   ** Declaring your themeConfig as a function gives you access to the default theme config as
+   ** an argument to that function.
+   */
   if (typeof _themeConfig === 'function')
     _themeConfig = _themeConfig(themeVariables, themeConfig);
 


### PR DESCRIPTION
This PR adds two new classes to the themeGenerator stylesheet:

```
      selectableRow: {
        ':hover': {
          cursor: 'pointer'
        }

      selectedRowIndicator: {
        padding: '10px'
      }
```

I'm about to post a PR for `simple-wallet` that will make use of these new styles. The idea is to make a table with "clickable rows" more UI familiar. `selectedRowIndicator` could be a checkbox, an arrow, etc.
