### PR TITLE
add, update, and delete config endpoints removed from core

### DIFF
--- a/configs/webpack.common.config.js
+++ b/configs/webpack.common.config.js
@@ -34,13 +34,15 @@ module.exports = () => {
       // this helps simplify plugin packages and ensures that parent classes
       // all point to the same instance, e.g bcoin.TX will be same for all plugins
       alias: {
-        bcoin$: `${MODULES_DIR}/bcoin/lib/bcoin-browser`,
+        '@bpanel/bpanel-utils': `${MODULES_DIR}/@bpanel/bpanel-utils`,
+        '@bpanel/bpanel-ui': `${MODULES_DIR}/@bpanel/bpanel-ui`,
         bcash$: `${MODULES_DIR}/bcash/lib/bcoin-browser`,
-        bsert: `${MODULES_DIR}/bsert`,
-        hsd$: `${MODULES_DIR}/hsd/lib/hsd-browser`,
+        bcoin$: `${MODULES_DIR}/bcoin/lib/bcoin-browser`,
+        bcrytpo: `${MODULES_DIR}/bcrypto`,
         bledger: `${MODULES_DIR}/bledger/lib/bledger-browser`,
         bmultisig: `${MODULES_DIR}/bmultisig/lib/bmultisig-browser`,
-        bcrytpo: `${MODULES_DIR}/bcrypto`,
+        bsert: `${MODULES_DIR}/bsert`,
+        hsd$: `${MODULES_DIR}/hsd/lib/hsd-browser`,
         react: `${MODULES_DIR}/react`,
         '&bpanel/pkg': `${ROOT_DIR}/pkg`,
         'react-dom': `${MODULES_DIR}/react-dom`,
@@ -50,8 +52,6 @@ module.exports = () => {
         redux: `${MODULES_DIR}/redux`,
         reselect: `${MODULES_DIR}/reselect`,
         '&local': path.resolve(bpanelPrefix, 'local_plugins'),
-        '@bpanel/bpanel-utils': `${MODULES_DIR}/@bpanel/bpanel-utils`,
-        '@bpanel/bpanel-ui': `${MODULES_DIR}/@bpanel/bpanel-ui`,
         tinycolor: 'tinycolor2'
       }
     },

--- a/configs/webpack.common.config.js
+++ b/configs/webpack.common.config.js
@@ -38,7 +38,7 @@ module.exports = () => {
         '@bpanel/bpanel-ui': `${MODULES_DIR}/@bpanel/bpanel-ui`,
         bcash$: `${MODULES_DIR}/bcash/lib/bcoin-browser`,
         bcoin$: `${MODULES_DIR}/bcoin/lib/bcoin-browser`,
-        bcrytpo: `${MODULES_DIR}/bcrypto`,
+        bcrypto: `${MODULES_DIR}/bcrypto`,
         bledger: `${MODULES_DIR}/bledger/lib/bledger-browser`,
         bmultisig: `${MODULES_DIR}/bmultisig/lib/bmultisig-browser`,
         bsert: `${MODULES_DIR}/bsert`,

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "autoprefixer": "7.1.5",
     "base64-inline-loader": "1.1.1",
     "bcash": "bcoin-org/bcash",
+    "bcfg": "0.1.4",
     "bclient": "0.1.4",
     "bcoin": "bcoin-org/bcoin",
     "bcrypto": "3.0.1",

--- a/server/endpoints/clients.js
+++ b/server/endpoints/clients.js
@@ -1,14 +1,12 @@
 const {
+  clientsHandler,
   getClientsInfo,
   getDefaultClientInfo,
-  clientsHandler,
   getConfigHandler,
-  addConfigHandler,
-  updateConfigHandler,
-  deleteConfigHandler
+  testClientsHandler
 } = require('../handlers/clients');
 
-const { GET, POST, PUT, DELETE, USE } = require('./methods');
+const { GET, USE } = require('./methods');
 
 const base = '/clients';
 
@@ -29,23 +27,13 @@ module.exports = [
     handler: clientsHandler
   },
   {
+    method: USE,
+    path: base.concat('/:id'),
+    handler: testClientsHandler
+  },
+  {
     method: GET,
     path: base.concat('/:id'),
     handler: getConfigHandler
-  },
-  {
-    method: POST,
-    path: base.concat('/:id'),
-    handler: addConfigHandler
-  },
-  {
-    method: PUT,
-    path: base.concat('/:id'),
-    handler: updateConfigHandler
-  },
-  {
-    method: DELETE,
-    path: base.concat('/:id'),
-    handler: deleteConfigHandler
   }
 ];

--- a/server/handlers/clients.js
+++ b/server/handlers/clients.js
@@ -156,7 +156,7 @@ async function testClientsHandler(req, res, next) {
         clientHealth.failed = clientErrors.failed;
         clientHealth.errors = clientErrors;
         clientHealth.healthy = false;
-        logger.warning('Proble checking configs for client "%s": ', id);
+        logger.warning('Problem checking configs for client "%s": ', id);
         logger.warning(clientErrors.message);
       }
       // attach clientHealth to request object

--- a/server/test/configHelpers-test.js
+++ b/server/test/configHelpers-test.js
@@ -13,7 +13,6 @@ const {
   createClientConfig,
   testConfigOptions,
   getConfig,
-  deleteConfig,
   ClientErrors
 } = configHelpers;
 
@@ -24,7 +23,7 @@ process.env.BPANEL_CLIENTS_DIR = 'test_clients';
 const { BPANEL_PREFIX, BPANEL_CLIENTS_DIR } = process.env;
 const clientsDirPath = resolve(BPANEL_PREFIX, BPANEL_CLIENTS_DIR);
 
-describe('configHelpers', () => {
+describe.only('configHelpers', () => {
   let node, apiKey, ports, options, id, config;
 
   before('create and start regtest node', async () => {
@@ -195,18 +194,6 @@ describe('configHelpers', () => {
         failed = true;
       }
       assert(failed, `Expected getConfig to fail for id "${failId}"`);
-    });
-  });
-
-  describe('deleteConfig', () => {
-    it('should remove a config file', async () => {
-      await createClientConfig(id, options);
-      let config = getConfig(id);
-      assert(config, 'Config did not exist before testing deletion');
-      deleteConfig(id);
-      const path = resolve(config.prefix, `${config.str('id')}.conf`);
-      const exists = fs.existsSync(path);
-      assert(!exists, 'Config should not exist after deletion');
     });
   });
 });

--- a/server/utils/apiFilters.js
+++ b/server/utils/apiFilters.js
@@ -23,8 +23,8 @@ function isBlacklisted(config, endpoint) {
       isMatch(path, blacklisted)
     )
       return true;
-    // for objects, will check path and method match
     else if (blacklisted.method === method && isMatch(path, blacklisted.path))
+      // for objects, will check path and method match
       return true;
   }
   // if no match, confirm not blacklisted


### PR DESCRIPTION
Changes include:
- support to set log level with config (e.g. `npm run start:poll -- --logLevel=debug` or in config.js)
- removes the PUT, POST, DELETE endpoints from bPanel core
- updates corresponding tests, and removes dedicated handlers
- handler to test health of a client is moved into its own dedicated middleware and attaches health information to the request object. This makes it possible for backend plugins to indicate that they want the health without having to implement themselves and then use the results downstream
- update the backend plugin api to support _BOTH_ before and after core middleware. This is used in the connection manager to have one middleware before that attaches a `health` query parameter so that the testHealth middleware will do the check and attach errors, and then the afterCoreMiddleware endpoints use that extra information for their operations.
- extra debug logging for when chokidar sees a change in the client directory