### PR TITLE
fixes for sidebar ordering and client health

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -204,7 +204,7 @@ will increase speed of future builds, so please be patient.'
       socketManager.addClients(id, {
         node: clients.get(id).nodeClient,
         wallet: clients.get(id).walletClient,
-        multisig: clients.get(id).multisigWalletClient
+        multisig: clients.get(id).multisigClient
       });
     }
 
@@ -234,7 +234,7 @@ will increase speed of future builds, so please be patient.'
             socketManager.addClients(id, {
               node: clients.get(id).nodeClient,
               wallet: clients.get(id).walletClient,
-              multisig: clients.get(id).multisigWalletClient
+              multisig: clients.get(id).multisigClient
             });
 
         // remove any clients from the socketManager not in our list

--- a/server/utils/clientFactory.js
+++ b/server/utils/clientFactory.js
@@ -14,19 +14,19 @@ const assert = require('assert');
 const Config = require('bcfg');
 
 const logger = require('../logger');
-const { loadClientConfigs, createConfigsMap } = require('./configs');
 
 const logClientInfo = (id, type, { ssl, host, port, network }) =>
   logger.info(
-    `${id}: Configuring ${type} client with uri: ${
-      ssl ? 'https' : 'http'
-    }://${host}:${port}, network: ${network}`
+    `${id}: Configuring ${type} client with uri: ${ssl
+      ? 'https'
+      : 'http'}://${host}:${port}, network: ${network}`
   );
+
 /*
  * Create clients based on given configs
  * @param {Config} config - a bcfg config object
  * @returns {Object} clients - an object that includes
- * a Node, Wallet, and Multisig Wallet clients as available
+ * a Node, Wallet, and Multisig clients as available
  */
 function clientFactory(config) {
   let Network, NodeClient, WalletClient;
@@ -111,7 +111,7 @@ function clientFactory(config) {
     }
   }
 
-  let walletClient, nodeClient, multisigWalletClient;
+  let walletClient, nodeClient, multisigClient;
   // check if config explicitly sets node config to `false`
   // if false, do not instantiate new node client
   if (config.bool('node', true)) {
@@ -127,14 +127,14 @@ function clientFactory(config) {
   }
 
   if (config.bool('multisig', true)) {
-    multisigWalletClient = new MultisigClient({
+    multisigClient = new MultisigClient({
       ...walletOptions,
       multisigPath: '/'
     });
     logClientInfo(id, 'multisig wallet', walletOptions);
   }
 
-  return { nodeClient, walletClient, multisigWalletClient };
+  return { nodeClient, walletClient, multisigClient };
 }
 
 /*

--- a/webapp/components/Sidebar.js
+++ b/webapp/components/Sidebar.js
@@ -90,9 +90,7 @@ class Sidebar extends PureComponent {
           // sanitize out any forward slashes or non-uri safe symbols from pathName
           // unless it is an absolute URL leading with http
           if (!/^(http)/.test(sidebarItemProps.pathName))
-            sidebarItemProps.pathName = `${match.url}${
-              sidebarItemProps.pathName
-            }`;
+            sidebarItemProps.pathName = `${match.url}${sidebarItemProps.pathName}`;
 
           if (plugin.parent) {
             // if this sidebar item is a child then add appropriate props
@@ -138,9 +136,8 @@ class Sidebar extends PureComponent {
     } = this.props;
     return (
       <nav
-        className={`${
-          theme.sidebar.container
-        } d-flex flex-column navbar navbar-default navbar-fixed-side`}
+        className={`${theme.sidebar
+          .container} d-flex flex-column navbar navbar-default navbar-fixed-side`}
       >
         {customSidebarHeader ? customSidebarHeader : this.renderLogo()}
         {beforeNav}

--- a/webapp/store/actions/clientActions.js
+++ b/webapp/store/actions/clientActions.js
@@ -13,17 +13,22 @@ function setClients(clients) {
 }
 
 function setCurrentClient(clientInfo) {
-  if (!clientInfo.chain && clientInfo.id)
-    // eslint-disable-next-line no-console
-    console.warn(
-      `No chain was set for client ${clientInfo.id}, defaulting to "bitcoin"`
-    );
-  const { id, chain = 'bitcoin' } = clientInfo;
-  // set the client info for the global client
-  if (id) client.setClientInfo(id, chain);
-  return {
-    type: SET_CURRENT_CLIENT,
-    payload: clientInfo
+  return async dispatch => {
+    if (!clientInfo.chain && clientInfo.id)
+      // eslint-disable-next-line no-console
+      console.warn(
+        `No chain was set for client ${clientInfo.id}, defaulting to "bitcoin"`
+      );
+    const { id, chain = 'bitcoin' } = clientInfo;
+    // get current information for client from server
+    const client = getClient();
+    const info = await client.getClientInfo(id, true);
+    // set the client info for the global client
+    if (id) client.setClientInfo(id, chain);
+    dispatch({
+      type: SET_CURRENT_CLIENT,
+      payload: { ...clientInfo, ...info }
+    });
   };
 }
 

--- a/webapp/store/selectors/nav.js
+++ b/webapp/store/selectors/nav.js
@@ -69,7 +69,9 @@ export function getNestedPaths(metadata) {
   assert(Array.isArray(metadata), 'Must pass array of metadata');
   return metadata.reduce((updated, _plugin) => {
     const plugin = { ..._plugin };
-    if (plugin.parent && !/^(http)/.test(plugin.pathName)) {
+    // setting a custom pathName if a sub-item and has no
+    // existing pathName set in metadata
+    if (plugin.parent && !plugin.pathName) {
       // if this plugin is a child then update its pathName property
       // to nest behind the parent
       const parentIndex = metadata.findIndex(

--- a/webapp/store/selectors/nav.js
+++ b/webapp/store/selectors/nav.js
@@ -117,10 +117,7 @@ function composeNavItems(_navItems = []) {
 }
 
 // selectors for converting pluginMetadata to nav list
-export const sortedNavItems = createSelector(
-  getMetadataList,
-  composeNavItems
-);
+export const sortedNavItems = createSelector(getMetadataList, composeNavItems);
 
 // selector for ordering and composing sidebar navigation items
 export const sortedSidebarItems = createSelector(
@@ -129,15 +126,10 @@ export const sortedSidebarItems = createSelector(
 );
 
 // Useful selector for the Panel which just needs to match names to paths
-export const uniquePathsByName = createSelector(
-  getMetadataList,
-  metadata =>
-    metadata
-      .filter(plugin => plugin.pathName)
-      .reduce(
-        (paths, { name, pathName }) => ({ ...paths, [name]: pathName }),
-        {}
-      )
+export const uniquePathsByName = createSelector(getMetadataList, metadata =>
+  metadata
+    .filter(plugin => plugin.pathName)
+    .reduce((paths, { name, pathName }) => ({ ...paths, [name]: pathName }), {})
 );
 
 export default {


### PR DESCRIPTION
Needed to fix some things for sidebar ordering to work:
- pathName was getting overwritten for subItems (originally had a functionality where these were automatically composed in relation to their parent, but this unfortunately interferes with React Router API)
- Confusing naming around multisig wallet client that caused some config problems. Changed all instances of `multisigWalletClient` -> `multisigClient`
- Beginning of combining clientHealth check with the services properties for client info. So if a server connection fails now, then a service will be marked as false. This doesn't work great though since we still have to use `getInfo` for all clients. I started to migrate to use `getWallets` for wallet clients, but there were two problems 1) a bug in [bmultisig](https://github.com/bcoin-org/bmultisig/issues/24) was breaking the call for multisig if there were no wallets 2) That endpoint only works for admin privileges. 
- add a check for client info before setting new current client (this actually just a fork from #144) 
