### PR TITLE
bugfix: remove extra div

### DIFF
--- a/webapp/components/Panel.js
+++ b/webapp/components/Panel.js
@@ -54,10 +54,6 @@ export default class extends PureComponent {
   }
 
   render() {
-    return (
-      <div>
-        <Switch>{this.routes}</Switch>
-      </div>
-    );
+    return <Switch>{this.routes}</Switch>;
   }
 }


### PR DESCRIPTION
Allows for Components to make use of things like `height: 100%` since they will not be constricted to this div

Tested against many plugins, none of them break because of this