### PR TITLE
remove z-index

### DIFF
--- a/webapp/config/themeConfig/themeCreator.js
+++ b/webapp/config/themeConfig/themeCreator.js
@@ -458,7 +458,7 @@ const themeCreator = (_themeVariables = {}, _themeConfig = {}) => {
         backgroundColor: themeColors.transparent,
         border: border2,
         borderBottomColor: themeColors.highlight1,
-        zIndex: '1'
+        zIndex: '0'
       },
       headerTextInactive: {
         backgroundColor: themeColors.darkBg,


### PR DESCRIPTION
Causing a problem with the border sitting on top of expandable menus. This removes the `zIndex: 1` property