### PR TITLE
Add support for starting with no available clients

### DIFF
--- a/server/build-plugins.js
+++ b/server/build-plugins.js
@@ -77,8 +77,9 @@ async function symlinkLocal(packageName) {
     // if it exists but is a symlink
     // remove symlink so we can replace with our new one
     if (stat.isSymbolicLink()) await fs.unlink(pkgDir);
-    // otherwise remove the old directory
-    else await fs.rimraf(pkgDir);
+    else
+      // otherwise remove the old directory
+      await fs.rimraf(pkgDir);
   }
 
   // for scoped packages, the scope becomes a parent directory
@@ -186,8 +187,9 @@ async function prepareModules(plugins = [], local = true, network = false) {
       if (existsLocal && local)
         // maintain support for plugins in plugins/local dir
         modulePath = `./${packageName}`;
-      // set import to webpack's alias for bpanel's local_plugins dir
-      else modulePath = local ? `&local/${packageName}` : packageName;
+      else
+        // set import to webpack's alias for bpanel's local_plugins dir
+        modulePath = local ? `&local/${packageName}` : packageName;
 
       // add plugin to list of packages that need to be installed w/ npm
       if (!local && existsRemote) installPackages.push(name);
@@ -225,7 +227,7 @@ async function prepareModules(plugins = [], local = true, network = false) {
         let newModules = false;
         for (let i = 0; i < installPackages.length; i++) {
           const pkg = installPackages[i];
-          newModules = !(await checkForModuleExistence(pkg));
+          newModules = !await checkForModuleExistence(pkg);
           if (newModules) break;
         }
 
@@ -234,8 +236,9 @@ async function prepareModules(plugins = [], local = true, network = false) {
           logger.info(
             'Skipping npm install of remote plugins due to lack of network connection'
           );
-        // if there are new modules, install them with npm
-        else if (newModules) await installRemotePackages(installPackages);
+        else if (newModules)
+          // if there are new modules, install them with npm
+          await installRemotePackages(installPackages);
         else
           logger.info('No new remote plugins to install. Skipping npm install');
       }

--- a/server/handlers/clients.js
+++ b/server/handlers/clients.js
@@ -49,18 +49,19 @@ function getClientsInfo(req, res) {
 
 function getDefaultClientInfo(req, res, next) {
   const { config } = req;
+  let defaultClientConfig;
   try {
-    const defaultClientConfig = getDefaultConfig(config);
+    defaultClientConfig = getDefaultConfig(config);
     const defaultClient = getClientInfo(defaultClientConfig, req.clientHealth);
-    if (!defaultClientConfig)
+    return res.status(200).json(defaultClient);
+  } catch (e) {
+    if (!defaultClientConfig || !config)
       return res.status(404).json({
         error: {
           message: `Sorry, there was no default client available`,
           code: 404
         }
       });
-    return res.status(200).json(defaultClient);
-  } catch (e) {
     next(e);
   }
 }

--- a/server/handlers/clients.js
+++ b/server/handlers/clients.js
@@ -52,6 +52,13 @@ function getDefaultClientInfo(req, res, next) {
   try {
     const defaultClientConfig = getDefaultConfig(config);
     const defaultClient = getClientInfo(defaultClientConfig, req.clientHealth);
+    if (!defaultClientConfig)
+      return res.status(404).json({
+        error: {
+          message: `Sorry, there was no default client available`,
+          code: 404
+        }
+      });
     return res.status(200).json(defaultClient);
   } catch (e) {
     next(e);

--- a/server/utils/clients.js
+++ b/server/utils/clients.js
@@ -163,7 +163,25 @@ function buildClients(config) {
   return { configsMap, clients };
 }
 
+/*
+ * utility function for getting object of clients
+ * @param {String} id - id of clients to retrieve
+ * @param {Map} clientsMap - map of all clients to get relevent
+ * @returns {Object} clients - object of only clients for that id
+ */
+function getClientsById(id, clientsMap) {
+  assert(typeof id === 'string', 'Expected an id of type string');
+  assert(clientsMap instanceof Map, 'Expected a map of clients');
+  const { nodeClient, walletClient, multisigClient } = clientsMap.get(id);
+  const clients = {};
+  if (nodeClient) clients.node = nodeClient;
+  if (walletClient) clients.wallet = walletClient;
+  if (multisigClient) clients.multisig = multisigClient;
+  return clients;
+}
+
 module.exports = {
   clientFactory,
-  buildClients
+  buildClients,
+  getClientsById
 };

--- a/server/utils/clients.js
+++ b/server/utils/clients.js
@@ -148,12 +148,6 @@ function buildClients(config) {
   // each of their configs.
   const clientConfigs = loadClientConfigs(config);
   const configsMap = createConfigsMap(clientConfigs);
-  if (!clientConfigs.length)
-    logger.warn(
-      'Could not find any client config files. You can use the Connection Manager \
-      settings plugin or read more about configuring connections in the documentation: \
-      https://bpanel.org/docs/configuration.html'
-    );
   const clients = clientConfigs.reduce((clientsMap, cfg) => {
     const id = cfg.str('id');
     assert(id, 'client config must have id');

--- a/server/utils/configs.js
+++ b/server/utils/configs.js
@@ -244,9 +244,8 @@ function getDefaultConfig(bpanelConfig) {
 
   if (!defaultClientConfig) {
     logger.warn(
-      `Could not find config for ${bpanelConfig.str(
-        'client-id'
-      )}. Will set to 'default' instead.`
+      'Could not find config for %s. Will set to "default" instead.',
+      bpanelConfig.str('client-id')
     );
     defaultClientConfig = clientConfigs.find(
       cfg => cfg.str('id') === 'default'

--- a/server/utils/configs.js
+++ b/server/utils/configs.js
@@ -235,12 +235,15 @@ function getDefaultConfig(bpanelConfig) {
     'Need the main bcfg for the app to get default configs'
   );
   const clientConfigs = loadClientConfigs(bpanelConfig);
+
+  if (!clientConfigs || !clientConfigs.length) return undefined;
+
   let defaultClientConfig = clientConfigs.find(
     cfg => cfg.str('id') === bpanelConfig.str('client-id', 'default')
   );
 
   if (!defaultClientConfig) {
-    logger.error(
+    logger.warn(
       `Could not find config for ${bpanelConfig.str(
         'client-id'
       )}. Will set to 'default' instead.`

--- a/server/utils/configs.js
+++ b/server/utils/configs.js
@@ -7,7 +7,7 @@ const Config = require('bcfg');
 
 const pkg = require('../../pkg');
 const logger = require('../logger');
-const { clientFactory } = require('../utils/clientFactory');
+const { clientFactory } = require('../utils/clients');
 
 /*
  * Load up a bcfg object for a given module and set of options

--- a/server/utils/configs.js
+++ b/server/utils/configs.js
@@ -79,14 +79,14 @@ function loadClientConfigs(_config) {
 
   // cancel startup process if there are no clientConfigs
   if (!files.length) {
-    logger.error('No client configs found.');
-    logger.error(
-      'Please add at least one config called "default" to your clients directory and try again.'
+    logger.warn(
+      'No client configs found. Add one manually to your clients directory \
+or use the connection-manager plugin to add via the UI'
     );
-    logger.error(
+    logger.warn(
       'Visit the documentation for more information: https://bpanel.org/docs/configuration.html'
     );
-    process.exit(1);
+    return files;
   }
 
   logger.info('Loading configs for %s clients...', files.length);

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -6,8 +6,9 @@
 
 exports.npmExists = require('./npm-exists');
 exports.configHelpers = require('./configs');
-exports.clientFactory = require('./clientFactory').clientFactory;
-exports.buildClients = require('./clientFactory').buildClients;
+exports.clientFactory = require('./clients').clientFactory;
+exports.buildClients = require('./clients').buildClients;
+exports.clientHelpers = require('./clients');
 exports.attach = require('./attach');
 exports.apiFilters = require('./apiFilters');
 exports.pluginUtils = require('./plugins');

--- a/webapp/containers/App/App.js
+++ b/webapp/containers/App/App.js
@@ -63,20 +63,20 @@ class App extends PureComponent {
   }
 
   async componentDidMount() {
-    const {
-      getNodeInfo,
-      connectSocket,
-      hydrateClients,
-      resetClient
-    } = this.props;
-
+    const { getNodeInfo, connectSocket, hydrateClients } = this.props;
     await hydrateClients();
     this.client = getClient();
-    this.client.on('set clients', clientInfo => {
-      resetClient(clientInfo);
+    this.client.on('set clients', clientInfo => this.updateClient(clientInfo));
+
+    if (this.client.id) {
+      connectSocket();
       getNodeInfo();
-    });
-    connectSocket();
+    }
+  }
+
+  updateClient(clientInfo) {
+    const { resetClient, getNodeInfo } = this.props;
+    resetClient(clientInfo);
     getNodeInfo();
   }
 
@@ -93,6 +93,9 @@ class App extends PureComponent {
     document.body.className = null;
     document.document.documentElement.className = null;
     this.props.disconnectSocket();
+    this.client.removeListener('set clients', clientInfo =>
+      this.updateClient(clientInfo)
+    );
   }
 
   getHomePath() {
@@ -107,48 +110,35 @@ class App extends PureComponent {
   }
 
   render() {
-    const {
-      sidebarNavItems,
-      location,
-      theme,
-      match,
-      currentClient
-    } = this.props;
+    const { sidebarNavItems, location, theme, match } = this.props;
     return (
       <ThemeProvider theme={theme}>
-        {currentClient.id ? (
-          <div>
-            <div
-              className={`${theme.app.container} container-fluid`}
-              role="main"
-            >
-              <div className="row">
-                <div
-                  className={`${theme.app.sidebarContainer} col-sm-4 col-lg-3`}
-                >
-                  <Sidebar
-                    sidebarNavItems={sidebarNavItems}
-                    location={location}
-                    theme={theme}
-                    match={match}
-                  />
-                </div>
-                <div className={`${theme.app.content} col-sm-8 col-lg-9`}>
-                  <Header />
-                  <Route
-                    exact
-                    path="/"
-                    render={() => <Redirect to={`/${this.getHomePath()}`} />}
-                  />
-                  <Panel />
-                </div>
+        <div>
+          <div className={`${theme.app.container} container-fluid`} role="main">
+            <div className="row">
+              <div
+                className={`${theme.app.sidebarContainer} col-sm-4 col-lg-3`}
+              >
+                <Sidebar
+                  sidebarNavItems={sidebarNavItems}
+                  location={location}
+                  theme={theme}
+                  match={match}
+                />
+              </div>
+              <div className={`${theme.app.content} col-sm-8 col-lg-9`}>
+                <Header />
+                <Route
+                  exact
+                  path="/"
+                  render={() => <Redirect to={`/${this.getHomePath()}`} />}
+                />
+                <Panel />
               </div>
             </div>
-            <Footer />
           </div>
-        ) : (
-          <div />
-        )}
+          <Footer />
+        </div>
       </ThemeProvider>
     );
   }

--- a/webapp/containers/App/App.js
+++ b/webapp/containers/App/App.js
@@ -113,7 +113,7 @@ class App extends PureComponent {
     const { sidebarNavItems, location, theme, match } = this.props;
     return (
       <ThemeProvider theme={theme}>
-        <div>
+        <React.Fragment>
           <div className={`${theme.app.container} container-fluid`} role="main">
             <div className="row">
               <div
@@ -138,7 +138,7 @@ class App extends PureComponent {
             </div>
           </div>
           <Footer />
-        </div>
+        </React.Fragment>
       </ThemeProvider>
     );
   }

--- a/webapp/store/constants/clients.js
+++ b/webapp/store/constants/clients.js
@@ -4,3 +4,4 @@ export const RESET_STATE = 'RESET_STATE';
 export const UPDATE_CLIENT = 'UPDATE_CLIENT';
 export const ADD_CLIENT = 'ADD_CLIENT';
 export const REMOVE_CLIENT = 'REMOVE_CLIENT';
+export const CLEAR_CURRENT_CLIENT = 'CLEAR_CURRENT_CLIENT';

--- a/webapp/store/middleware.js
+++ b/webapp/store/middleware.js
@@ -1,6 +1,10 @@
 import { getClient } from '@bpanel/bpanel-utils';
 
-import { SET_CURRENT_CLIENT } from './constants/clients';
+import {
+  SET_CURRENT_CLIENT,
+  CLEAR_CURRENT_CLIENT,
+  RESET_STATE
+} from './constants/clients';
 
 export function errorCatcherMiddleware(errorHandler) {
   return function(store) {
@@ -9,9 +13,7 @@ export function errorCatcherMiddleware(errorHandler) {
         try {
           return next(action);
         } catch (err) {
-          const message = `There was an error in the middleware for the action ${
-            action.type
-          }: `;
+          const message = `There was an error in the middleware for the action ${action.type}: `;
           errorHandler(message, err, store.getState, action, store.dispatch);
           return err;
         }
@@ -20,7 +22,7 @@ export function errorCatcherMiddleware(errorHandler) {
   };
 }
 
-export function clientMiddleware() {
+export function clientMiddleware({ dispatch }) {
   return function(next) {
     return function(action) {
       const client = getClient();
@@ -30,13 +32,14 @@ export function clientMiddleware() {
         if (!clientInfo.chain && clientInfo.id)
           // eslint-disable-next-line no-console
           console.warn(
-            `No chain was set for client ${
-              clientInfo.id
-            }, defaulting to "bitcoin"`
+            `No chain was set for client ${clientInfo.id}, defaulting to "bitcoin"`
           );
         const { id, chain = 'bitcoin' } = clientInfo;
         // set the client info for the global client
         if (id) client.setClientInfo(id, chain);
+      } else if (action.type === CLEAR_CURRENT_CLIENT) {
+        client.reset();
+        dispatch({ type: RESET_STATE });
       }
       return next(action);
     };

--- a/webapp/store/reducers/clients.js
+++ b/webapp/store/reducers/clients.js
@@ -3,7 +3,8 @@ import {
   REMOVE_CLIENT,
   SET_CLIENTS,
   SET_CURRENT_CLIENT,
-  UPDATE_CLIENT
+  UPDATE_CLIENT,
+  CLEAR_CURRENT_CLIENT
 } from '../constants/clients';
 import assert from 'bsert';
 
@@ -58,6 +59,11 @@ const clientsState = (state = initialState, action) => {
       const { id } = payload;
       delete newState.clients[id];
       newState.clients = { ...newState.clients };
+      return newState;
+    }
+
+    case CLEAR_CURRENT_CLIENT: {
+      newState.currentClient = {};
       return newState;
     }
 


### PR DESCRIPTION
This will supersede PR #144 which was causing more problems than it was solving. 

Backend Updates:
- put try/catch around client factory and refactor as per comments in other PR with a dedicated utility
- will display app even if no clients are available
- Removes the thrown errors and process exits on the server when no existing configs are found. just logs warnings

Frontend Updates:
- cleaned up listeners on the App mount
- added reducer and middleware for clearing the current state

Requires an update from bpanel and also improves the performance for connection manager w/ an update to it. 