### PR TITLE
Docker: fix builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,27 @@ RUN apk upgrade --no-cache && \
     apk add --no-cache git python make g++ bash && \
     npm install -g npm@$NPM_VERSION
 
+# install dependencies for node-hid
+RUN apk add --no-cache linux-headers eudev-dev libusb-dev
+# install handshake deps
+RUN apk add --no-cache unbound-dev
+
 COPY package.json \
      package-lock.json \
      /usr/src/app/
 
 # Install dependencies
 FROM base AS build
-# install dependencies for node-hid
-RUN apk add --no-cache linux-headers eudev-dev libusb-dev
+
+# allow for install to
+# parse commit
+RUN mkdir .git
+COPY .git/logs .git/logs
+
+# dont run preinstall scripts here
+# by omitting --unsafe-perm
 RUN npm install
+
 # this is a grandchild dependency of hsd that gets skipped for some reason
 # and needs to be installed manually
 RUN npm install budp

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,6 @@ COPY package.json \
 # Install dependencies
 FROM base AS build
 
-# allow for install to
-# parse commit
-RUN mkdir .git
-COPY .git/logs .git/logs
-
 # dont run preinstall scripts here
 # by omitting --unsafe-perm
 RUN npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN npm install budp
 # Bundle app
 FROM base
 COPY --from=build /usr/src/app/node_modules /usr/src/app/node_modules
+COPY pkg.js /usr/src/app/pkg.js
+COPY vendor /usr/src/app/vendor
 COPY scripts /usr/src/app/scripts
 COPY configs /usr/src/app/configs
 COPY server /usr/src/app/server

--- a/Dockerfile-bcoin
+++ b/Dockerfile-bcoin
@@ -26,7 +26,6 @@ RUN npm init -y &>/dev/null \
   bcoin-org/blgr \
   bcoin-org/bclient
 
-
 # TODO: Inherit from official image
 FROM base
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ progress in your container.
 Read more about how to connect a local instance of bPanel to a bcoin node running in docker
 [here](#local-bpanel-dev-using-bcoin-docker-container).
 
+#### Plugins with Docker Compose
+It's possible to set which plugins you want loaded via an environment variable `BPANEL_PLUGINS`.
+The docker compose has this set for you and can be customized according to your needs.
+Note however that once set, they cannot be edited using the methods listed
+[below](#managing-plugins). To make changes, you will need to edit `docker-compose.yml` and
+restart the container. Comment out this environment variable to use the config.js instead.
+
 ## Managing Plugins
 
 Plugin management is handled in a `config.js` file located by default in the `.bpanel` directory in your

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ version: '3'
 services:
   bpanel:
     ## Build to use local Dockerfile
-    # build: .
+    build: .
     ## Build from image from docker hub
-    image: bpanel/bpanel
+    # image: bpanel/bpanel
     restart: unless-stopped
     environment:
       # Need this to tell the bpanel client
@@ -46,15 +46,15 @@ services:
 
   bcoin:
     ## Use image to to pull from docker hub
-    image: bpanel/bcoin
+    # image: bpanel/bcoin
     ## Build to use local Dockerfile-bcoin
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile-bcoin
-      # args:
-      #   repo: https://github.com/bcoin-org/bcoin.git
-      #   branch: master
-      #   rebuild: 0
+    build:
+      context: .
+      dockerfile: Dockerfile-bcoin
+      args:
+        repo: https://github.com/bcoin-org/bcoin.git
+        branch: master
+        rebuild: 0
     restart: unless-stopped
     env_file:
       # Set arguments to use in bcoin-init.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       # how to communicate with the bcoin node
       # in docker
       _DOCKER_NODE_HOST: bcoin
+      # Edit this to add/remove plugins!
+      BPANEL_PLUGINS: '@bpanel/genesis-theme,@bpanel/bui'
     ports:
       - "5000:5000"
       - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,17 +2,18 @@ version: '3'
 services:
   bpanel:
     ## Build to use local Dockerfile
-    build: .
+    # build: .
     ## Build from image from docker hub
-    # image: bpanel/bpanel
+    image: bpanel/bpanel:dev
     restart: unless-stopped
     environment:
       # Need this to tell the bpanel client
       # how to communicate with the bcoin node
       # in docker
       _DOCKER_NODE_HOST: bcoin
-      # Edit this to add/remove plugins!
-      BPANEL_PLUGINS: '@bpanel/genesis-theme,@bpanel/bui'
+      # Edit this to add/remove plugins! This cannot be edited after startup
+      # even with bpanel's config.js. Must edit below, and rebuild container.
+      BPANEL_PLUGINS: '@bpanel/genesis-theme,@bpanel/bui,@bpanel/connection-manager'
     ports:
       - "5000:5000"
       - "5001:5001"
@@ -47,15 +48,15 @@ services:
 
   bcoin:
     ## Use image to to pull from docker hub
-    # image: bpanel/bcoin
+    image: bpanel/bcoin:dev
     ## Build to use local Dockerfile-bcoin
-    build:
-      context: .
-      dockerfile: Dockerfile-bcoin
-      args:
-        repo: https://github.com/bcoin-org/bcoin.git
-        branch: master
-        rebuild: 0
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile-bcoin
+    #   args:
+    #     repo: https://github.com/bcoin-org/bcoin.git
+    #     branch: master
+    #     rebuild: 0
     restart: unless-stopped
     env_file:
       # Set arguments to use in bcoin-init.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       BPANEL_PLUGINS: '@bpanel/genesis-theme,@bpanel/bui'
     ports:
       - "5000:5000"
+      - "5001:5001"
       - "8000:8000"
     volumes:
       ## Mapping to local files- Handy for dev

--- a/securityc.env
+++ b/securityc.env
@@ -15,4 +15,4 @@ KEY_OUT=/etc/ssl/nginx/tls.key
 USE_NGINX=true
 NGINX_SSL_CERTIFICATE=/etc/ssl/nginx/tls.crt
 NGINX_SSL_CERTIFICATE_KEY=/etc/ssl/nginx/tls.key
-NGINX_UPSTREAM_URI=app:5000
+NGINX_UPSTREAM_URI=bpanel:5000

--- a/webapp/plugins/local/.gitkeep
+++ b/webapp/plugins/local/.gitkeep
@@ -1,0 +1,3 @@
+# commit empty directory
+# build-plugins script will generate an index.js file
+# in this directory automatically


### PR DESCRIPTION
Also: Dockerhub should be updated to build images off of the `development` branch, OR master should get bumped.   I think having both `:dev` & `:stable` images is the best solution.  