### PR TITLE
endpoints: add curl

### DIFF
--- a/server/endpoints/clients.js
+++ b/server/endpoints/clients.js
@@ -3,7 +3,8 @@ const {
   getClientsInfo,
   getDefaultClientInfo,
   getConfigHandler,
-  testClientsHandler
+  testClientsHandler,
+  curl
 } = require('../handlers/clients');
 
 const { GET, USE } = require('./methods');
@@ -35,5 +36,10 @@ module.exports = [
     method: GET,
     path: base.concat('/:id'),
     handler: getConfigHandler
+  },
+  {
+    method: GET,
+    path: '/curl/:host/:path',
+    handler: curl
   }
 ];

--- a/server/handlers/clients.js
+++ b/server/handlers/clients.js
@@ -241,7 +241,7 @@ async function curl(req, res) {
     logger.warning(e);
     return res.status(500).json({
       error: {
-        messgae: `There was a problem fetching ${url}`,
+        message: `There was a problem fetching ${url}`,
         code: 500
       }
     });

--- a/server/handlers/clients.js
+++ b/server/handlers/clients.js
@@ -1,5 +1,6 @@
 const Config = require('bcfg');
 const assert = require('bsert');
+const bcurl = require('bcurl');
 
 const { configHelpers, clientFactory } = require('../utils');
 const { getDefaultConfig, testConfigOptions, getConfig } = configHelpers;
@@ -228,10 +229,30 @@ async function getConfigHandler(req, res) {
   return res.status(200).json(info);
 }
 
+async function curl(req, res) {
+  const { logger, params } = req;
+  const url = params.host + '/' + params.path;
+  try {
+    logger.info('Fetching json from ' + url);
+    const client = bcurl.client(params.host);
+    const json = await client.get(params.path);
+    return res.status(200).json(json);
+  } catch (e) {
+    logger.warning(e);
+    return res.status(500).json({
+      error: {
+        messgae: `There was a problem fetching ${url}`,
+        code: 500
+      }
+    });
+  }
+}
+
 module.exports = {
   clientsHandler,
   getClientsInfo,
   getConfigHandler,
   getDefaultClientInfo,
-  testClientsHandler
+  testClientsHandler,
+  curl
 };


### PR DESCRIPTION
Creates a new bPanel API endpoint `/curl` which accepts two parameters `host` and `path`:
`'/curl/:host/:path'`

Handled by `curl()` in clients.js, executes a `bcurl.get()` to fetch JSON from a remote API.

PRs will follow for bpanel-utils and price. The motivation here is to allow the bpanel client to fetch API data without CORS errors. Using this new `/curl` endpoint, all API requests go through the server!