### PR TITLE
remove lookbehind

### DIFF
--- a/server/utils/configs.js
+++ b/server/utils/configs.js
@@ -186,7 +186,7 @@ async function testConfigOptions(options) {
           if (info) {
             const { pool: { agent } } = info;
             // find implementation from user agent
-            const implementation = agent.match(/(?<=\/)(\w*)(?=:)/)[0];
+            const implementation = agent.match(/(\w*)(?=:)/)[0];
             assert(agents.has(implementation), `Agent ${agent} not supported.`);
             if (agents.get(implementation) !== chain)
               throw new Error(

--- a/server/utils/configs.js
+++ b/server/utils/configs.js
@@ -186,7 +186,7 @@ async function testConfigOptions(options) {
           if (info) {
             const { pool: { agent } } = info;
             // find implementation from user agent
-            const implementation = agent.match(/(\w*)(?=:)/)[0];
+            const implementation = agent.match(/([\w\s]*)(?=:)/)[0];
             assert(agents.has(implementation), `Agent ${agent} not supported.`);
             if (agents.get(implementation) !== chain)
               throw new Error(


### PR DESCRIPTION
Allows support for versions of node older than v9. The lookbehind checked for the agent string between two forward slashes, but that isn't strictly necessary as this will still check the agent correctly. 