### PR TITLE
Consolidate loggers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,8 @@ module.exports = {
   ],
   rules: {
     'prettier/prettier': 'error',
-    'no-empty': ['error', { allowEmptyCatch: true }]
+    'no-empty': ['error', { allowEmptyCatch: true }],
+    'no-param-reassign': 'warn'
   },
   settings: {
     react: {

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ For complete developer and API documentation, visit our website: https://bpanel.
 - [Managing Plugins](#managing-plugins)
 - [Configuration](#configuration)
 - [About the Docker Environment](#about-the-docker-environment)
+- [Logging](#logging)
 - [Extending bPanel](#extending-bpanel)
-
+- [Troubleshooting & FAQ](#troubleshooting--faq)
 ## Dependencies
 
 - npm >= 5.7.1
@@ -245,6 +246,17 @@ can also persist your bcoin data within the named `bcoin` volume or on the host 
 
 Uncomment the relevant `build:` sections in `docker-compose.yml`
 for the services you want to build, then run `docker-compose build`
+
+## Logging
+By default, the bPanel server will log to your console and create a debug.log file in your
+prefix directory (defaults to `~/.bpanel`). The logger can be configured via command line
+arguments, your `config.js`, environment variables (prefaced with `BPANEL_`). See
+[Configuration](#configuration) for more on setting bPanel configurations.
+
+bPanel uses the [blgr](https://github.com/bcoin-org/blgr/) module for logging.
+You can set custom values for level, file, console, and shrink. All but level are
+boolean (true/false). Available options for level are: none, error, warning, info, debug, and spam.
+See [blgr](https://github.com/bcoin-org/blgr/) for more info.
 
 ## Extending bPanel
 

--- a/configs/webpack.common.config.js
+++ b/configs/webpack.common.config.js
@@ -4,7 +4,6 @@ const webpack = require('webpack');
 const WebpackShellPlugin = require('webpack-synchronizable-shell-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-const logger = require('../server/logger');
 const { MODULES_DIR, SRC_DIR, SERVER_DIR, ROOT_DIR } = require('./constants');
 
 // can be passed by server process via bcfg interface
@@ -16,69 +15,68 @@ const bpanelPrefix =
 // socket port hard coded in since running on a different port from
 // file server and http proxy
 const BPANEL_SOCKET_PORT = process.env.BPANEL_SOCKET_PORT || 8000;
+let SECRETS = {};
+try {
+  SECRETS = require(path.resolve(bpanelPrefix, 'secrets.json'));
+} catch (e) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `Couldn't find secrets.json in ${bpanelPrefix}. Make sure to run npm install to create boilerplate files`
+  );
+}
 
-module.exports = () => {
-  let SECRETS = {};
-  try {
-    SECRETS = require(path.resolve(bpanelPrefix, 'secrets.json'));
-  } catch (e) {
-    logger.error(
-      `Couldn't find secrets.json in ${bpanelPrefix}. Make sure to run npm install to create boilerplate files`
-    );
-  }
-  return {
-    resolve: {
-      symlinks: false,
-      extensions: ['-browser.js', '.js', '.json', '.jsx'],
-      // list of aliases are what packages plugins can list as peerDeps
-      // this helps simplify plugin packages and ensures that parent classes
-      // all point to the same instance, e.g bcoin.TX will be same for all plugins
-      alias: {
-        '@bpanel/bpanel-utils': `${MODULES_DIR}/@bpanel/bpanel-utils`,
-        '@bpanel/bpanel-ui': `${MODULES_DIR}/@bpanel/bpanel-ui`,
-        bcash$: `${MODULES_DIR}/bcash/lib/bcoin-browser`,
-        bcoin$: `${MODULES_DIR}/bcoin/lib/bcoin-browser`,
-        bcrypto: `${MODULES_DIR}/bcrypto`,
-        bledger: `${MODULES_DIR}/bledger/lib/bledger-browser`,
-        bmultisig: `${MODULES_DIR}/bmultisig/lib/bmultisig-browser`,
-        bsert: `${MODULES_DIR}/bsert`,
-        hsd$: `${MODULES_DIR}/hsd/lib/hsd-browser`,
-        react: `${MODULES_DIR}/react`,
-        '&bpanel/pkg': `${ROOT_DIR}/pkg`,
-        'react-dom': `${MODULES_DIR}/react-dom`,
-        'react-router': `${MODULES_DIR}/react-router`,
-        'react-router-dom': `${MODULES_DIR}/react-router-dom`,
-        'react-redux': `${MODULES_DIR}/react-redux`,
-        redux: `${MODULES_DIR}/redux`,
-        reselect: `${MODULES_DIR}/reselect`,
-        '&local': path.resolve(bpanelPrefix, 'local_plugins'),
-        tinycolor: 'tinycolor2'
+module.exports = () => ({
+  resolve: {
+    symlinks: false,
+    extensions: ['-browser.js', '.js', '.json', '.jsx'],
+    // list of aliases are what packages plugins can list as peerDeps
+    // this helps simplify plugin packages and ensures that parent classes
+    // all point to the same instance, e.g bcoin.TX will be same for all plugins
+    alias: {
+      '@bpanel/bpanel-utils': `${MODULES_DIR}/@bpanel/bpanel-utils`,
+      '@bpanel/bpanel-ui': `${MODULES_DIR}/@bpanel/bpanel-ui`,
+      bcash$: `${MODULES_DIR}/bcash/lib/bcoin-browser`,
+      bcoin$: `${MODULES_DIR}/bcoin/lib/bcoin-browser`,
+      bcrypto: `${MODULES_DIR}/bcrypto`,
+      bledger: `${MODULES_DIR}/bledger/lib/bledger-browser`,
+      bmultisig: `${MODULES_DIR}/bmultisig/lib/bmultisig-browser`,
+      bsert: `${MODULES_DIR}/bsert`,
+      hsd$: `${MODULES_DIR}/hsd/lib/hsd-browser`,
+      react: `${MODULES_DIR}/react`,
+      '&bpanel/pkg': `${ROOT_DIR}/pkg`,
+      'react-dom': `${MODULES_DIR}/react-dom`,
+      'react-router': `${MODULES_DIR}/react-router`,
+      'react-router-dom': `${MODULES_DIR}/react-router-dom`,
+      'react-redux': `${MODULES_DIR}/react-redux`,
+      redux: `${MODULES_DIR}/redux`,
+      reselect: `${MODULES_DIR}/reselect`,
+      '&local': path.resolve(bpanelPrefix, 'local_plugins'),
+      tinycolor: 'tinycolor2'
+    }
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      title: 'bPanel - A Blockchain Management System',
+      template: `${path.join(SRC_DIR, 'index.template.ejs')}`,
+      inject: 'body'
+    }),
+    new WebpackShellPlugin({
+      onBuildStart: {
+        scripts: [
+          `node ${path.resolve(SERVER_DIR, 'clear-plugins.js')}`,
+          `node ${path.resolve(
+            SERVER_DIR,
+            'build-plugins.js'
+          )} --prefix=${bpanelPrefix}`
+        ]
       }
-    },
-    plugins: [
-      new HtmlWebpackPlugin({
-        title: 'bPanel - A Blockchain Management System',
-        template: `${path.join(SRC_DIR, 'index.template.ejs')}`,
-        inject: 'body'
-      }),
-      new WebpackShellPlugin({
-        onBuildStart: {
-          scripts: [
-            `node ${path.resolve(SERVER_DIR, 'clear-plugins.js')}`,
-            `node ${path.resolve(
-              SERVER_DIR,
-              'build-plugins.js'
-            )} --prefix=${bpanelPrefix}`
-          ]
-        }
-      }),
-      new webpack.DefinePlugin({
-        SECRETS: JSON.stringify(SECRETS),
-        BPANEL_SOCKET_PORT: JSON.stringify(BPANEL_SOCKET_PORT),
-        NODE_ENV: `"${process.env.NODE_ENV}"`,
-        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-        'process.env.BROWSER': JSON.stringify(true)
-      })
-    ]
-  };
-};
+    }),
+    new webpack.DefinePlugin({
+      SECRETS: JSON.stringify(SECRETS),
+      BPANEL_SOCKET_PORT: JSON.stringify(BPANEL_SOCKET_PORT),
+      NODE_ENV: `"${process.env.NODE_ENV}"`,
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+      'process.env.BROWSER': JSON.stringify(true)
+    })
+  ]
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.0.tgz",
-      "integrity": "sha512-b4v7dyfApuKDvmPb+O488UlGuR1WbwMXFsO/cyqMrnfvRAChZKJAYeeglWTjUO1b9UghKKgepAQM5tsvBJca6A==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.2.tgz",
+      "integrity": "sha512-fKCuD6UFUMkR541eDWL+2ih/xFZBXPOg/7EQFeTluMDebfqR4jrpaCjLhkWlQS4hT6nRa2PMEgXKbRB5/H2fpg==",
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.10",
@@ -113,23 +113,48 @@
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
       "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
     },
-    "@sinonjs/formatio": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
-      "integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
+    "@sinonjs/commons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
       "dev": true,
       "requires": {
-        "@sinonjs/samsam": "2.1.0"
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/samsam": "^2 || ^3"
       }
     },
     "@sinonjs/samsam": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
-      "integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.2.tgz",
+      "integrity": "sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==",
       "dev": true,
       "requires": {
-        "array-from": "^2.1.1"
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash.get": "^4.4.2"
+      },
+      "dependencies": {
+        "lodash.get": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+          "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+          "dev": true
+        }
       }
+    },
+    "@types/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA==",
+      "dev": true
     },
     "@webassemblyjs/ast": {
       "version": "1.5.13",
@@ -494,9 +519,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-      "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+      "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -505,9 +530,9 @@
       }
     },
     "ajv-errors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.0.tgz",
-      "integrity": "sha1-7PAh+hCP0X37Xms4Py3SM+Mf/Fk="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
     },
     "ajv-keywords": {
       "version": "3.2.0",
@@ -563,15 +588,16 @@
       }
     },
     "ansi-colors": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.1.tgz",
-      "integrity": "sha512-Xt+zb6nqgvV9SWAVp0EG3lRsHcbq5DDgqjPPz6pwgtj6RKz65zGXMNa82oJfOSBA/to6GmRP7Dr+6o+kbApTzQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
       "dev": true
     },
     "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+      "version": "3.1.0",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -608,7 +634,8 @@
     "app-root-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.1.0.tgz",
-      "integrity": "sha1-mL9lmTJ+zqGZMJhm6BQDaP0uZGo="
+      "integrity": "sha1-mL9lmTJ+zqGZMJhm6BQDaP0uZGo=",
+      "dev": true
     },
     "aproba": {
       "version": "1.2.0",
@@ -777,9 +804,13 @@
       "dev": true
     },
     "async": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
-      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.10"
+      }
     },
     "async-each": {
       "version": "1.0.1",
@@ -1552,9 +1583,9 @@
       }
     },
     "babel-plugin-macros": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.2.tgz",
-      "integrity": "sha512-NBVpEWN4OQ/bHnu1fyDaAaTPAjnhXCEPqr1RwqxrU7b6tZ2hypp+zX4hlNfmVGfClD5c3Sl6Hfj5TJNF5VG5aA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.3.tgz",
+      "integrity": "sha512-M8cE1Rx0zgfKYBWAS+T6ZVCLGuTKdBI5Rn3fu9q6iVdH0UjaXdmF501/VEYn7kLHCgguhGNk5JBzOn64e2xDEA==",
       "requires": {
         "cosmiconfig": "^5.0.5",
         "resolve": "^1.8.1"
@@ -2034,7 +2065,7 @@
       "dependencies": {
         "regexpu-core": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
           "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
           "dev": true,
           "requires": {
@@ -2175,9 +2206,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
+          "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw=="
         },
         "regenerator-runtime": {
           "version": "0.10.5",
@@ -2310,9 +2341,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
+          "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw==",
           "dev": true
         }
       }
@@ -2327,9 +2358,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
+          "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw=="
         },
         "regenerator-runtime": {
           "version": "0.11.1",
@@ -2495,7 +2526,7 @@
       "dev": true
     },
     "bcash": {
-      "version": "github:bcoin-org/bcash#15f7a9128147976a3213b4ee6a5602803fe51d20",
+      "version": "github:bcoin-org/bcash#bcd24d163b07b5c33097f5d95086ada6b15135f3",
       "from": "github:bcoin-org/bcash",
       "requires": {
         "bcfg": "~0.1.4",
@@ -2570,9 +2601,9 @@
           }
         },
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         },
         "bsock": {
           "version": "0.1.4",
@@ -2600,11 +2631,6 @@
             "bsert": "~0.0.5",
             "bsock": "~0.1.4"
           }
-        },
-        "nan": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
         }
       }
     },
@@ -2617,9 +2643,9 @@
       },
       "dependencies": {
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -2634,7 +2660,7 @@
       }
     },
     "bcoin": {
-      "version": "github:bcoin-org/bcoin#d88fa6714775c67e00c4170c95d6f60a6ea92159",
+      "version": "github:bcoin-org/bcoin#208c40891ff5a5a25af0adefa2bdaf527343f142",
       "from": "github:bcoin-org/bcoin",
       "requires": {
         "bcfg": "~0.1.4",
@@ -2651,7 +2677,7 @@
         "blru": "~0.1.4",
         "blst": "~0.1.3",
         "bmutex": "~0.1.4",
-        "bsert": "~0.0.5",
+        "bsert": "~0.0.7",
         "bsip": "~0.1.4",
         "bsock": "~0.1.4",
         "bsocks": "~0.2.3",
@@ -2709,9 +2735,9 @@
           }
         },
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         },
         "bsock": {
           "version": "0.1.4",
@@ -2739,11 +2765,6 @@
             "bsert": "~0.0.5",
             "bsock": "~0.1.4"
           }
-        },
-        "nan": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
         }
       }
     },
@@ -2768,14 +2789,9 @@
       },
       "dependencies": {
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
-        },
-        "nan": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -2800,11 +2816,6 @@
             "bufio": "~1.0.2",
             "nan": "~2.11.0"
           }
-        },
-        "nan": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
         }
       }
     },
@@ -2829,14 +2840,9 @@
       },
       "dependencies": {
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
-        },
-        "nan": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -2849,9 +2855,9 @@
       },
       "dependencies": {
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -2873,9 +2879,9 @@
       },
       "dependencies": {
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -2895,9 +2901,9 @@
       },
       "dependencies": {
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -2910,9 +2916,9 @@
       },
       "dependencies": {
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -2985,16 +2991,11 @@
           },
           "dependencies": {
             "bsert": {
-              "version": "0.0.6",
-              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.6.tgz",
-              "integrity": "sha512-Rddj7b623cGW3K4Km8mFdVVhWDfDlm2MjYCwXm8lmhqRuPLVAKylcXNk5v2+QZJP5uW4BqkA8z1C69Fp2CCbRg=="
+              "version": "0.0.7",
+              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+              "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
             }
           }
-        },
-        "nan": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
         }
       }
     },
@@ -3018,9 +3019,9 @@
       },
       "dependencies": {
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -3033,9 +3034,9 @@
       },
       "dependencies": {
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -3084,9 +3085,9 @@
           },
           "dependencies": {
             "bsert": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-              "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+              "version": "0.0.7",
+              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+              "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
             }
           }
         },
@@ -3099,9 +3100,9 @@
           },
           "dependencies": {
             "bsert": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-              "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+              "version": "0.0.7",
+              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+              "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
             }
           }
         },
@@ -3115,11 +3116,16 @@
           },
           "dependencies": {
             "bsert": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-              "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+              "version": "0.0.7",
+              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+              "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
             }
           }
+        },
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
         }
       }
     },
@@ -3132,9 +3138,9 @@
       },
       "dependencies": {
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -3176,11 +3182,6 @@
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/bfile/-/bfile-0.1.3.tgz",
           "integrity": "sha512-7OScx3u416zFsloaN2CyVXRwVAOJdFBpNrpvGlUbkVD2gEzpj+d7/38MInEXnFtcmErDiY1DFR2URBT4J/7kRg=="
-        },
-        "nan": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
         }
       }
     },
@@ -3411,9 +3412,9 @@
       },
       "dependencies": {
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -3426,9 +3427,9 @@
       },
       "dependencies": {
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -3448,14 +3449,9 @@
       },
       "dependencies": {
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
-        },
-        "nan": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -3495,9 +3491,9 @@
           }
         },
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -3510,6 +3506,13 @@
         "bsert": "~0.0.4",
         "n64": "~0.2.1",
         "nan": "~2.10.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+        }
       }
     },
     "btcp": {
@@ -3610,9 +3613,9 @@
           }
         },
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -3625,9 +3628,9 @@
       },
       "dependencies": {
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -3756,14 +3759,14 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000913",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000913.tgz",
-      "integrity": "sha512-+3qNxt3n8TaF+ZQOiRFPjP+OltDCJkHc7dSlMu1GlLu6sBnLPGLZMogNOlkI96+gft/Mn8u6Z10GMKVOxiBckQ=="
+      "version": "1.0.30000921",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000921.tgz",
+      "integrity": "sha512-sAvmRuxZ457rlTK+ydUMpmeXjVfkiXQXv0POTdpHEdKrVwEQaeZqJgQA5MH7sKAGTGxzlLcDpfoNkpVXw09X5Q=="
     },
     "caniuse-lite": {
-      "version": "1.0.30000913",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000913.tgz",
-      "integrity": "sha512-PP7Ypc35XY1mNduHqweGNOp0qfNUCmaQauGOYDByvirlFjrzRyY72pBRx7jnBidOB8zclg00DAzsy2H475BouQ=="
+      "version": "1.0.30000921",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000921.tgz",
+      "integrity": "sha512-Bu09ciy0lMWLgpYC77I0YGuI8eFRBPPzaSOYJK1jTI64txCphYCqnWbxJYjHABYVt/TYX/p3jNjLBR87u1Bfpw=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -3960,25 +3963,36 @@
       }
     },
     "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
       "requires": {
-        "restore-cursor": "^1.0.1"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-spinners": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
-      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw="
+      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+      "dev": true
     },
     "cli-truncate": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
       "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
       "requires": {
         "slice-ansi": "0.0.4",
         "string-width": "^1.0.1"
+      },
+      "dependencies": {
+        "slice-ansi": {
+          "version": "0.0.4",
+          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+          "dev": true
+        }
       }
     },
     "cli-width": {
@@ -4130,7 +4144,8 @@
     "commander": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -4260,7 +4275,7 @@
     },
     "content-disposition": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
@@ -4444,9 +4459,9 @@
       },
       "dependencies": {
         "postcss": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-          "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -4753,14 +4768,14 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.3.5",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.5.tgz",
-          "integrity": "sha512-z9ZhGc3d9e/sJ9dIx5NFXkKoaiQTnrvrMsN3R1fGb1tkWWNSz12UewJn9TNxGo1l7J23h0MRaPmk7jfeTZYs1w==",
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.6.tgz",
+          "integrity": "sha512-kMGKs4BTzRWviZ8yru18xBpx+CyHG9eqgRbj9XbE3IMgtczf4aiA0Y1YCpVdvUieKGZ03kolSPXqTcscBCb9qw==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000912",
-            "electron-to-chromium": "^1.3.86",
-            "node-releases": "^1.0.5"
+            "caniuse-lite": "^1.0.30000921",
+            "electron-to-chromium": "^1.3.92",
+            "node-releases": "^1.1.1"
           }
         },
         "caniuse-api": {
@@ -4776,11 +4791,13 @@
           }
         },
         "coa": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.1.tgz",
-          "integrity": "sha512-5wfTTO8E2/ja4jFSxePXlG5nRu5bBtL/r1HCIpJW/lzT6yDtKl0u0Z4o/Vpz32IpKmBn7HerheEZQgA9N2DarQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+          "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
           "dev": true,
           "requires": {
+            "@types/q": "^1.5.1",
+            "chalk": "^2.4.1",
             "q": "^1.1.2"
           }
         },
@@ -4875,9 +4892,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-          "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -5198,9 +5215,9 @@
       },
       "dependencies": {
         "postcss": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-          "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -5242,11 +5259,6 @@
       "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
       "dev": true
     },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
-    },
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -5278,9 +5290,10 @@
       }
     },
     "date-fns": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
     },
     "date-format": {
       "version": "1.2.0",
@@ -5533,9 +5546,9 @@
       "dev": true
     },
     "domelementtype": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.2.1.tgz",
-      "integrity": "sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
     },
     "domhandler": {
@@ -5564,11 +5577,6 @@
       "requires": {
         "is-obj": "^1.0.0"
       }
-    },
-    "dotenv": {
-      "version": "5.0.1",
-      "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-      "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -5608,14 +5616,15 @@
       "integrity": "sha512-Vlrbs//2bQTsFdOQixJXgTfCQ9BwOTXhlMV5AV/1lwDzqBtMSlpdHTLc7dkTbexs0ZyByR1SD6zQ+HmFJ2T3sw=="
     },
     "electron-to-chromium": {
-      "version": "1.3.87",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.87.tgz",
-      "integrity": "sha512-EV5FZ68Hu+n9fHVhOc9AcG3Lvf+E1YqR36ulJUpwaQTkf4LwdvBqmGIazaIrt4kt6J8Gw3Kv7r9F+PQjAkjWeA=="
+      "version": "1.3.94",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.94.tgz",
+      "integrity": "sha512-miQqXALb6eBD3OetCtg3UM5XTLMwHISux0l6mh14iiV5SE+qvftgOCXT9Vvp53fWaCLET4sfA/SmIMYHXkaNmw=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
     },
     "elliptic": {
       "version": "6.4.1",
@@ -6294,7 +6303,8 @@
     "exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
     },
     "expand-braces": {
       "version": "0.1.2",
@@ -6602,11 +6612,6 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
-    "eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
-    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -6666,12 +6671,12 @@
       }
     },
     "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -6952,25 +6957,21 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+          "bundled": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+          "bundled": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -6979,13 +6980,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "bundled": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6993,35 +6992,29 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+          "bundled": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "ms": "2.0.0"
@@ -7029,26 +7022,22 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+          "bundled": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+          "bundled": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -7056,14 +7045,12 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -7078,8 +7065,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -7092,14 +7078,12 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "safer-buffer": "^2.1.0"
@@ -7107,8 +7091,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -7116,8 +7099,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "once": "^1.3.0",
@@ -7126,46 +7108,39 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "bundled": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+          "bundled": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7173,8 +7148,7 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -7182,22 +7156,19 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "debug": "^2.1.2",
@@ -7207,8 +7178,7 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
-          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -7225,8 +7195,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "abbrev": "1",
@@ -7235,14 +7204,12 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+          "bundled": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -7251,8 +7218,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -7263,39 +7229,33 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -7304,20 +7264,17 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "bundled": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "deep-extend": "^0.5.1",
@@ -7328,16 +7285,14 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -7351,8 +7306,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "glob": "^7.0.5"
@@ -7360,43 +7314,36 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+          "bundled": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+          "bundled": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "bundled": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7405,8 +7352,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -7414,22 +7360,19 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "chownr": "^1.0.1",
@@ -7443,14 +7386,12 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "string-width": "^1.0.2"
@@ -7458,13 +7399,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+          "bundled": true
         }
       }
     },
@@ -7510,7 +7449,8 @@
     "get-own-enumerable-property-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
-      "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg=="
+      "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==",
+      "dev": true
     },
     "get-stdin": {
       "version": "5.0.1",
@@ -7917,31 +7857,6 @@
             "nan": "~2.11.0"
           }
         },
-        "bcurl": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.1.4.tgz",
-          "integrity": "sha512-wy+/9uBQWrcNcMy4qCl241qATNnB0evBO5oTJboINXXG3c152wDyEnedAvypkOp4Mh0fYrlsO6yYr5RmRXnVIQ==",
-          "requires": {
-            "brq": "~0.1.4",
-            "bsert": "~0.0.5",
-            "bsock": "~0.1.4"
-          },
-          "dependencies": {
-            "bsert": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-              "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
-            },
-            "bsock": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.4.tgz",
-              "integrity": "sha512-3hfPScf58kC13udMqXL/GiBubUOmwwMaTljIY8xJI0pO2uOmAaDyBCqT/PiteXRHHC1lDinK2wkFayc4xX92Wg==",
-              "requires": {
-                "bsert": "~0.0.5"
-              }
-            }
-          }
-        },
         "bfile": {
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/bfile/-/bfile-0.1.3.tgz",
@@ -7956,9 +7871,9 @@
           },
           "dependencies": {
             "bsert": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-              "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+              "version": "0.0.7",
+              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+              "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
             }
           }
         },
@@ -7973,9 +7888,9 @@
           },
           "dependencies": {
             "bsert": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-              "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+              "version": "0.0.7",
+              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+              "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
             }
           }
         },
@@ -7989,9 +7904,9 @@
           },
           "dependencies": {
             "bsert": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-              "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+              "version": "0.0.7",
+              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+              "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
             },
             "bsock": {
               "version": "0.1.4",
@@ -8002,28 +7917,6 @@
               }
             }
           }
-        },
-        "hs-client": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/hs-client/-/hs-client-0.0.4.tgz",
-          "integrity": "sha512-rwdf19HbnScPNjFEltD4aJG7HZnl+ZannAceckyEkupUiGERTuZ+xUvRXtx2eSW256P95xJpKEHHCe/f7X6uOw==",
-          "requires": {
-            "bcfg": "~0.1.4",
-            "bcurl": "~0.1.4",
-            "bsert": "~0.0.5"
-          },
-          "dependencies": {
-            "bsert": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-              "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
-            }
-          }
-        },
-        "nan": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
         }
       }
     },
@@ -8308,6 +8201,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
       "requires": {
         "repeating": "^2.0.0"
       }
@@ -8374,60 +8268,17 @@
         "through": "^2.3.6"
       },
       "dependencies": {
-        "ansi-escapes": {
-          "version": "3.1.0",
-          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-          "dev": true
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^2.0.0"
-          }
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-          }
         },
         "string-width": {
           "version": "2.1.1",
@@ -8500,7 +8351,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -8572,7 +8423,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -8647,6 +8498,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -8742,7 +8594,8 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -8761,7 +8614,8 @@
     "is-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
     },
     "is-relative": {
       "version": "0.2.1",
@@ -8866,7 +8720,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "jest-docblock": {
       "version": "21.2.0",
@@ -8877,12 +8732,14 @@
     "jest-get-type": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
-      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q=="
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
     },
     "jest-validate": {
       "version": "21.2.1",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
       "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
       "requires": {
         "chalk": "^2.0.1",
         "jest-get-type": "^21.2.0",
@@ -8990,9 +8847,9 @@
       "dev": true
     },
     "just-extend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
-      "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
     },
     "karma": {
@@ -9031,9 +8888,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
+          "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw==",
           "dev": true
         },
         "mime": {
@@ -9129,17 +8986,6 @@
         "loader-utils": "^1.1.0",
         "source-map": "^0.5.6",
         "webpack-dev-middleware": "^3.2.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.10"
-          }
-        }
       }
     },
     "kew": {
@@ -9220,7 +9066,8 @@
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -9236,6 +9083,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-4.3.0.tgz",
       "integrity": "sha512-C/Zxslg0VRbsxwmCu977iIs+QyrmW2cyRCPUV5NDFYOH/jtRFHH8ch7ua2fH0voI/nVC3Tpg7DykfgMZySliKw==",
+      "dev": true,
       "requires": {
         "app-root-path": "^2.0.0",
         "chalk": "^2.1.0",
@@ -9258,6 +9106,7 @@
           "version": "1.1.0",
           "resolved": "http://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
           "integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "js-yaml": "^3.4.3",
@@ -9273,6 +9122,7 @@
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
           "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
             "get-stream": "^3.0.0",
@@ -9286,12 +9136,14 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
           "requires": {
             "error-ex": "^1.2.0"
           }
@@ -9299,7 +9151,8 @@
         "require-from-string": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-          "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
+          "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+          "dev": true
         }
       }
     },
@@ -9307,6 +9160,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
       "integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
+      "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "cli-truncate": "^0.2.1",
@@ -9329,12 +9183,14 @@
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -9343,10 +9199,21 @@
             "supports-color": "^2.0.0"
           }
         },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
         "log-symbols": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
           "requires": {
             "chalk": "^1.0.0"
           }
@@ -9354,19 +9221,22 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
     "listr-silent-renderer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
     },
     "listr-update-renderer": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
       "integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
+      "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "cli-truncate": "^0.2.1",
@@ -9381,12 +9251,14 @@
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -9395,15 +9267,27 @@
             "supports-color": "^2.0.0"
           }
         },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
         "indent-string": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
         },
         "log-symbols": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
           "requires": {
             "chalk": "^1.0.0"
           }
@@ -9411,7 +9295,8 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -9419,6 +9304,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
       "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "cli-cursor": "^1.0.2",
@@ -9429,12 +9315,14 @@
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -9443,10 +9331,46 @@
             "supports-color": "^2.0.0"
           }
         },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -9557,6 +9481,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
       "requires": {
         "chalk": "^2.0.1"
       }
@@ -9565,9 +9490,43 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
       "requires": {
         "ansi-escapes": "^1.0.0",
         "cli-cursor": "^1.0.2"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        }
       }
     },
     "log4js": {
@@ -9742,9 +9701,9 @@
       }
     },
     "memoize-one": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.1.0.tgz",
-      "integrity": "sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+      "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
     },
     "memoizee": {
       "version": "0.3.10",
@@ -10010,9 +9969,9 @@
       }
     },
     "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
+      "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA=="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -10039,14 +9998,9 @@
       },
       "dependencies": {
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
-        },
-        "nan": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -10067,9 +10021,9 @@
       "integrity": "sha512-wry9grq4tNsxvpW2hqXNJIxqv9pT3+NEs/nyg9z5nKQ4QCB6b9IF2DSpVBEC/9fxX6c6G5hJ+SzK/Iv2k+896w=="
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -10125,13 +10079,13 @@
       "dev": true
     },
     "nise": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz",
-      "integrity": "sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+      "integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "3.0.0",
-        "just-extend": "^3.0.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "just-extend": "^4.0.2",
         "lolex": "^2.3.2",
         "path-to-regexp": "^1.7.0",
         "text-encoding": "^0.6.4"
@@ -10238,9 +10192,9 @@
       }
     },
     "node-releases": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.5.tgz",
-      "integrity": "sha512-Ky7q0BO1BBkG/rQz6PkEZ59rwo+aSfhczHP1wwq8IowoVdN/FpiP7qp0XW0P2+BVCWe5fQUBozdbVd54q1RbCQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.1.tgz",
+      "integrity": "sha512-2UXrBr6gvaebo5TNF84C66qyJJ6r0kxBObgZIDX3D3/mt1ADKiHux3NJPWisq0wxvJJdkjECH+9IIKYViKj71Q==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -10339,6 +10293,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
       "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+      "dev": true,
       "requires": {
         "which": "^1.2.10"
       }
@@ -10355,6 +10310,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
       "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
       "requires": {
         "commander": "^2.9.0",
         "npm-path": "^2.0.2",
@@ -10513,9 +10469,13 @@
       }
     },
     "onetime": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
     },
     "optimist": {
       "version": "0.6.1",
@@ -10558,9 +10518,9 @@
           }
         },
         "postcss": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-          "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -10594,6 +10554,7 @@
       "version": "0.2.3",
       "resolved": "http://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+      "dev": true,
       "requires": {
         "chalk": "^1.1.1",
         "cli-cursor": "^1.0.2",
@@ -10604,12 +10565,14 @@
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -10618,10 +10581,36 @@
             "supports-color": "^2.0.0"
           }
         },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -10730,7 +10719,8 @@
     "p-map": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
     },
     "p-try": {
       "version": "1.0.0",
@@ -10857,7 +10847,7 @@
     },
     "path-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
@@ -10967,12 +10957,14 @@
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -12254,9 +12246,9 @@
       },
       "dependencies": {
         "postcss": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-          "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -12285,9 +12277,9 @@
       },
       "dependencies": {
         "postcss": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-          "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -12316,9 +12308,9 @@
       },
       "dependencies": {
         "postcss": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-          "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -12346,9 +12338,9 @@
       },
       "dependencies": {
         "postcss": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-          "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -12376,9 +12368,9 @@
       },
       "dependencies": {
         "postcss": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-          "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -12406,20 +12398,20 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.3.5",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.5.tgz",
-          "integrity": "sha512-z9ZhGc3d9e/sJ9dIx5NFXkKoaiQTnrvrMsN3R1fGb1tkWWNSz12UewJn9TNxGo1l7J23h0MRaPmk7jfeTZYs1w==",
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.6.tgz",
+          "integrity": "sha512-kMGKs4BTzRWviZ8yru18xBpx+CyHG9eqgRbj9XbE3IMgtczf4aiA0Y1YCpVdvUieKGZ03kolSPXqTcscBCb9qw==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000912",
-            "electron-to-chromium": "^1.3.86",
-            "node-releases": "^1.0.5"
+            "caniuse-lite": "^1.0.30000921",
+            "electron-to-chromium": "^1.3.92",
+            "node-releases": "^1.1.1"
           }
         },
         "postcss": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-          "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -12507,9 +12499,9 @@
       },
       "dependencies": {
         "postcss": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-          "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -13026,6 +13018,7 @@
       "version": "21.2.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
       "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^3.0.0",
         "ansi-styles": "^3.2.0"
@@ -13034,7 +13027,8 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         }
       }
     },
@@ -13056,9 +13050,9 @@
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.2.tgz",
-      "integrity": "sha512-/OLz5F9beZUWwSHZDreXgap1XShX6W+DCHQCqwCF7uZ88s6uTlD2cR3JBE77SegCmNtb1Idst+NfmwcdU6KVhw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "promise": {
@@ -13106,15 +13100,15 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
       "dev": true
     },
     "pstree.remy": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.2.tgz",
-      "integrity": "sha512-vL6NLxNHzkNTjGJUpMm5PLC+94/0tTlC1vkP9bdU0pOHih+EujMjgMTwfZopZvHWRFbqJ5Y73OMoau50PewDDA=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.6.tgz",
+      "integrity": "sha512-NdF35+QsqD7EgNEI5mkI/X+UwaxVEbQaz9f4IooEmMUv6ZPmlTQYGjBPJGgrlzNdjSvIy4MWMg6Q6vCgBO2K+w=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -13621,13 +13615,6 @@
         "lodash-es": "^4.2.1",
         "loose-envify": "^1.1.0",
         "symbol-observable": "^1.0.3"
-      },
-      "dependencies": {
-        "symbol-observable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-        }
       }
     },
     "redux-devtools-extension": {
@@ -13687,7 +13674,7 @@
     },
     "regexpu-core": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
       "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
       "requires": {
         "regenerate": "^1.2.1",
@@ -13763,6 +13750,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
       "requires": {
         "is-finite": "^1.0.0"
       }
@@ -13874,11 +13862,11 @@
       "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
     },
     "resolve": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+      "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-cwd": {
@@ -13906,12 +13894,13 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
       "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -13998,8 +13987,17 @@
       "version": "5.5.12",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
       "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+      "dev": true,
       "requires": {
         "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {
@@ -14248,9 +14246,21 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -14526,9 +14536,9 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "spdx-correct": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-      "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -14563,7 +14573,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
@@ -14598,15 +14608,11 @@
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "dev": true
     },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
-    },
     "staged-git-files": {
       "version": "0.0.4",
       "resolved": "http://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
-      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU="
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
     },
     "static-extend": {
       "version": "0.1.2",
@@ -14674,7 +14680,8 @@
     "stream-to-observable": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
-      "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4="
+      "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
+      "dev": true
     },
     "streamroller": {
       "version": "0.7.0",
@@ -14717,7 +14724,7 @@
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
         "code-point-at": "^1.0.0",
@@ -14737,6 +14744,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
       "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
       "requires": {
         "get-own-enumerable-property-symbols": "^3.0.0",
         "is-obj": "^1.0.1",
@@ -14818,20 +14826,20 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.3.5",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.5.tgz",
-          "integrity": "sha512-z9ZhGc3d9e/sJ9dIx5NFXkKoaiQTnrvrMsN3R1fGb1tkWWNSz12UewJn9TNxGo1l7J23h0MRaPmk7jfeTZYs1w==",
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.6.tgz",
+          "integrity": "sha512-kMGKs4BTzRWviZ8yru18xBpx+CyHG9eqgRbj9XbE3IMgtczf4aiA0Y1YCpVdvUieKGZ03kolSPXqTcscBCb9qw==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000912",
-            "electron-to-chromium": "^1.3.86",
-            "node-releases": "^1.0.5"
+            "caniuse-lite": "^1.0.30000921",
+            "electron-to-chromium": "^1.3.92",
+            "node-releases": "^1.1.1"
           }
         },
         "postcss": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-          "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -14907,9 +14915,9 @@
       }
     },
     "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "table": {
       "version": "4.0.3",
@@ -14936,15 +14944,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
-        },
-        "slice-ansi": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0"
-          }
         },
         "string-width": {
           "version": "2.1.1",
@@ -15077,7 +15076,7 @@
     },
     "timers-browserify": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "resolved": "http://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
@@ -15216,7 +15215,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
@@ -15358,14 +15357,6 @@
       "requires": {
         "bindings": "~1.3.1",
         "nan": "~2.11.1"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.11.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-          "optional": true
-        }
       }
     },
     "unc-path-regex": {
@@ -15381,11 +15372,6 @@
       "requires": {
         "debug": "^2.2.0"
       }
-    },
-    "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "union-value": {
       "version": "1.0.0",
@@ -15564,9 +15550,9 @@
           "integrity": "sha512-7OScx3u416zFsloaN2CyVXRwVAOJdFBpNrpvGlUbkVD2gEzpj+d7/38MInEXnFtcmErDiY1DFR2URBT4J/7kRg=="
         },
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w=="
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g=="
         }
       }
     },
@@ -15726,7 +15712,7 @@
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true,
       "requires": {
@@ -15922,12 +15908,6 @@
         "yargs": "^12.0.1"
       },
       "dependencies": {
-        "ansi-escapes": {
-          "version": "3.1.0",
-          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-          "dev": true
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -15939,15 +15919,6 @@
           "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
           "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
           "dev": true
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^2.0.0"
-          }
         },
         "cross-spawn": {
           "version": "6.0.5",
@@ -15982,15 +15953,6 @@
             "chardet": "^0.7.0",
             "iconv-lite": "^0.4.24",
             "tmp": "^0.0.33"
-          }
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
           }
         },
         "inquirer": {
@@ -16028,25 +15990,6 @@
           "requires": {
             "errno": "^0.1.3",
             "readable-stream": "^2.0.1"
-          }
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
           }
         },
         "rxjs": {
@@ -16267,26 +16210,6 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
-        }
-      }
-    },
-    "winston": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
-      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
-      "requires": {
-        "async": "~1.0.0",
-        "colors": "1.0.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "stack-trace": "0.0.x"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,9 +47,9 @@
       }
     },
     "@bpanel/bpanel-utils": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@bpanel/bpanel-utils/-/bpanel-utils-0.1.6.tgz",
-      "integrity": "sha512-Nae8/6fDWP+To9Nqfux7akdOVibt80rkSeLrgdeOQwh5khjX4wzk48zs5aXvekcnn9s3G0okd8OlpHxpRaYoYw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@bpanel/bpanel-utils/-/bpanel-utils-0.1.7.tgz",
+      "integrity": "sha512-S1BCJNvsmeTbx3VEDMuHcoqX5/kuSUtB//OOaqTGMVt0QaFQr3005PEOhULVaW2DwS5Tsce++4tPc7UI0/Wq9A==",
       "requires": {
         "bcurl": "^0.1.3",
         "bsert": "0.0.4",
@@ -2065,7 +2065,7 @@
       "dependencies": {
         "regexpu-core": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
           "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
           "dev": true,
           "requires": {
@@ -2526,7 +2526,7 @@
       "dev": true
     },
     "bcash": {
-      "version": "github:bcoin-org/bcash#bcd24d163b07b5c33097f5d95086ada6b15135f3",
+      "version": "github:bcoin-org/bcash#15f7a9128147976a3213b4ee6a5602803fe51d20",
       "from": "github:bcoin-org/bcash",
       "requires": {
         "bcfg": "~0.1.4",
@@ -2660,7 +2660,7 @@
       }
     },
     "bcoin": {
-      "version": "github:bcoin-org/bcoin#208c40891ff5a5a25af0adefa2bdaf527343f142",
+      "version": "github:bcoin-org/bcoin#d88fa6714775c67e00c4170c95d6f60a6ea92159",
       "from": "github:bcoin-org/bcoin",
       "requires": {
         "bcfg": "~0.1.4",
@@ -2677,7 +2677,7 @@
         "blru": "~0.1.4",
         "blst": "~0.1.3",
         "bmutex": "~0.1.4",
-        "bsert": "~0.0.7",
+        "bsert": "~0.0.5",
         "bsip": "~0.1.4",
         "bsock": "~0.1.4",
         "bsocks": "~0.2.3",
@@ -4275,7 +4275,7 @@
     },
     "content-disposition": {
       "version": "0.5.2",
-      "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
@@ -8351,7 +8351,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -8423,7 +8423,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -10847,7 +10847,7 @@
     },
     "path-browserify": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
@@ -13674,7 +13674,7 @@
     },
     "regexpu-core": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
       "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
       "requires": {
         "regenerate": "^1.2.1",
@@ -14573,7 +14573,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
@@ -14724,7 +14724,7 @@
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
         "code-point-at": "^1.0.0",
@@ -15076,7 +15076,7 @@
     },
     "timers-browserify": {
       "version": "1.4.2",
-      "resolved": "http://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
@@ -15215,7 +15215,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
@@ -15712,7 +15712,7 @@
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "compression": "1.7.3",
     "cors": "2.8.4",
     "css-loader": "0.28.11",
-    "dotenv": "5.0.1",
     "effects-middleware": "1.0.1",
     "express": "4.16.2",
     "file-loader": "2.0.0",
@@ -77,7 +76,6 @@
     "hsd": "handshake-org/hsd#7f6e6ba277f43011fa873338fa693e85d4e3a907",
     "husky": "0.15.0-rc.7",
     "level-js": "2.2.4",
-    "lint-staged": "4.3.0",
     "lodash": "4.17.10",
     "nodemon": "1.18.6",
     "postcss-loader": "2.0.8",
@@ -94,9 +92,7 @@
     "reselect": "3.0.1",
     "semver": "5.5.0",
     "style-loader": "0.19.0",
-    "underscore": "1.8.3",
-    "validate-npm-package-name": "3.0.0",
-    "winston": "2.4.0"
+    "validate-npm-package-name": "3.0.0"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",
@@ -131,6 +127,7 @@
     "karma-sinon": "1.0.5",
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "4.0.0-rc.5",
+    "lint-staged": "4.3.0",
     "mini-css-extract-plugin": "0.4.2",
     "mocha": "4.0.1",
     "optimize-css-assets-webpack-plugin": "5.0.1",

--- a/server/build-plugins.js
+++ b/server/build-plugins.js
@@ -9,7 +9,7 @@ const { format } = require('prettier');
 const { execSync } = require('child_process');
 const validate = require('validate-npm-package-name');
 
-const logger = require('./logger');
+const { createLogger } = require('./logger');
 const { npmExists } = require('./utils');
 
 const config = new Config('bpanel');
@@ -35,6 +35,8 @@ const getPackageName = name => {
 };
 
 async function installRemotePackages(installPackages) {
+  const logger = createLogger();
+  await logger.open();
   const pkgStr = installPackages.reduce((str, name) => {
     if (validate(name).validForNewPackages) str = `${str} ${name}`;
     return str;
@@ -53,8 +55,10 @@ async function installRemotePackages(installPackages) {
 in node_modules. Try deleting the node_modules directory and running `npm install` again.'
     );
     logger.error(e.stack);
+    await logger.close();
     process.exit(1);
   }
+  await logger.close();
 }
 
 /*
@@ -63,6 +67,9 @@ in node_modules. Try deleting the node_modules directory and running `npm instal
  * This allows webpack to watch for changes.
  */
 async function symlinkLocal(packageName) {
+  const logger = createLogger();
+  await logger.open();
+
   logger.info(`Creating symlink for local plugin ${packageName}...`);
   const pkgDir = resolve(MODULES_DIRECTORY, packageName);
 
@@ -108,6 +115,8 @@ async function symlinkLocal(packageName) {
       resolve(HOME_PREFIX, 'local_plugins', packageName),
       resolve(MODULES_DIRECTORY, pkgDir)
     );
+
+  await logger.close();
 }
 
 // a utility method to check if a module exists in node_modules
@@ -134,6 +143,9 @@ async function getLocalPlugins() {
 }
 
 async function prepareModules(plugins = [], local = true, network = false) {
+  const logger = createLogger();
+  await logger.open();
+
   let pluginsIndex = local
     ? '// exports for all local plugin modules\n\n'
     : '// exports for all published plugin modules\n\n';
@@ -244,7 +256,10 @@ async function prepareModules(plugins = [], local = true, network = false) {
       }
     } catch (e) {
       logger.error('Error installing plugins packages: ', e);
+      await logger.close();
     }
+
+    await logger.close();
   }
 
   exportsText += ']); \n }';
@@ -257,6 +272,8 @@ async function prepareModules(plugins = [], local = true, network = false) {
 }
 
 (async () => {
+  const logger = createLogger();
+  await logger.open();
   try {
     assert(
       fs.existsSync(PLUGINS_CONFIG),
@@ -291,4 +308,5 @@ your config file.'
   } catch (err) {
     logger.error('There was an error preparing modules: ', err.stack);
   }
+  await logger.close();
 })();

--- a/server/build-plugins.js
+++ b/server/build-plugins.js
@@ -57,8 +57,9 @@ in node_modules. Try deleting the node_modules directory and running `npm instal
     logger.error(e.stack);
     await logger.close();
     process.exit(1);
+  } finally {
+    await logger.close();
   }
-  await logger.close();
 }
 
 /*
@@ -256,10 +257,9 @@ async function prepareModules(plugins = [], local = true, network = false) {
       }
     } catch (e) {
       logger.error('Error installing plugins packages: ', e);
+    } finally {
       await logger.close();
     }
-
-    await logger.close();
   }
 
   exportsText += ']); \n }';
@@ -307,6 +307,7 @@ your config file.'
     });
   } catch (err) {
     logger.error('There was an error preparing modules: ', err.stack);
+  } finally {
+    await logger.close();
   }
-  await logger.close();
 })();

--- a/server/clear-plugins.js
+++ b/server/clear-plugins.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const fs = require('bfile');
-const logger = require('./logger');
+const { createLogger } = require('./logger');
 const { resolve } = require('path');
 
-module.exports = () => {
+module.exports = async () => {
   const indexText =
     'export default async function() { return Promise.all([]); }';
   const pluginsPath = resolve(__dirname, '../webapp/plugins');
@@ -12,7 +12,10 @@ module.exports = () => {
     fs.writeFileSync(resolve(pluginsPath, 'local/index.js'), indexText);
     fs.writeFileSync(resolve(pluginsPath, 'index.js'), indexText);
   } catch (e) {
+    const logger = createLogger();
+    await logger.open();
     logger.error('There was an error clearing plugins: ', e);
+    await logger.close();
   }
 };
 

--- a/server/handlers/clients.js
+++ b/server/handlers/clients.js
@@ -161,8 +161,6 @@ async function testClientsHandler(req, res, next) {
     try {
       const { data } = getConfig(id);
       configOptions = { ...data, ...configOptions };
-      config = loadConfig(configOptions.id, configOptions);
-      config.set('logger', logger);
     } catch (e) {
       // if missing config, can disregard
       if (e.code === 'ENOENT')
@@ -173,6 +171,8 @@ async function testClientsHandler(req, res, next) {
     const clientHealth = {};
 
     try {
+      config = loadConfig(configOptions.id, configOptions);
+      config.set('logger', logger);
       logger.info('Checking health of client "%s"...', id);
       const [err, clientErrors] = await testConfigOptions(config);
       if (!err) {

--- a/server/handlers/clients.js
+++ b/server/handlers/clients.js
@@ -52,14 +52,11 @@ function getClientsInfo(req, res) {
   return res.status(200).json(clientInfo);
 }
 
-function getDefaultClientInfo(req, res, next) {
+async function getDefaultClientInfo(req, res, next) {
   const { config } = req;
   let defaultClientConfig;
   try {
-    defaultClientConfig = getDefaultConfig(config);
-    const defaultClient = getClientInfo(defaultClientConfig, req.clientHealth);
-    return res.status(200).json(defaultClient);
-  } catch (e) {
+    defaultClientConfig = await getDefaultConfig(config);
     if (!defaultClientConfig || !config)
       return res.status(404).json({
         error: {
@@ -67,6 +64,9 @@ function getDefaultClientInfo(req, res, next) {
           code: 404
         }
       });
+    const defaultClient = getClientInfo(defaultClientConfig, req.clientHealth);
+    return res.status(200).json(defaultClient);
+  } catch (e) {
     next(e);
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,7 @@ const fs = require('bfile');
 const { execSync } = require('child_process');
 const os = require('os');
 const { createLogger } = require('./logger');
-const Blgr = require('blgr');
+const Logger = require('blgr');
 const chokidar = require('chokidar');
 
 const webpackArgs = [];
@@ -136,13 +136,13 @@ module.exports = async (_config = {}) => {
   const bpanelConfig = loadConfig('bpanel', _config);
 
   // build logger from config
-  const logger = new Blgr();
+  const logger = new Logger();
 
   logger.set({
     filename: bpanelConfig.bool('log-file')
       ? bpanelConfig.location('debug.log')
       : null,
-    level: bpanelConfig.str('log-level', 'debug'),
+    level: bpanelConfig.str('log-level', 'info'),
     console: bpanelConfig.bool('log-console', true),
     shrink: bpanelConfig.bool('log-shrink', true)
   });

--- a/server/index.js
+++ b/server/index.js
@@ -160,7 +160,11 @@ will increase speed of future builds, so please be patient.'
     watch: [`${bpanelConfig.prefix}/config.js`],
     env: {
       BPANEL_PREFIX: bpanelConfig.prefix,
-      BPANEL_SOCKET_PORT: bsockPort
+      BPANEL_SOCKET_PORT: bsockPort,
+      BPANEL_LOG_LEVEL: bpanelConfig.str('log-level', 'info'),
+      BPANEL_LOG_FILE: bpanelConfig.bool('log-file', true),
+      BPANEL_LOG_CONSOLE: bpanelConfig.bool('log-console', true),
+      BPANEL_LOG_SHRINK: bpanelConfig.bool('log-shrink', true)
     },
     args: webpackArgs,
     legacyWatch: poll

--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,6 @@ const fs = require('bfile');
 const { execSync } = require('child_process');
 const os = require('os');
 const { createLogger } = require('./logger');
-const Logger = require('blgr');
 const chokidar = require('chokidar');
 
 const webpackArgs = [];
@@ -136,16 +135,7 @@ module.exports = async (_config = {}) => {
   const bpanelConfig = loadConfig('bpanel', _config);
 
   // build logger from config
-  const logger = new Logger();
-
-  logger.set({
-    filename: bpanelConfig.bool('log-file')
-      ? bpanelConfig.location('debug.log')
-      : null,
-    level: bpanelConfig.str('log-level', 'info'),
-    console: bpanelConfig.bool('log-console', true),
-    shrink: bpanelConfig.bool('log-shrink', true)
-  });
+  const logger = createLogger(bpanelConfig);
   bpanelConfig.set('logger', logger);
   await logger.open();
 

--- a/server/logger.js
+++ b/server/logger.js
@@ -11,7 +11,9 @@ function createLogger(_config) {
 
   const logger = new Logger();
   logger.set({
-    filename: config.bool('log-file') ? config.location('debug.log') : null,
+    filename: config.bool('log-file', true)
+      ? config.location('debug.log')
+      : null,
     level: config.str('log-level', 'info'),
     console: config.bool('log-console', true),
     shrink: config.bool('log-shrink', true)

--- a/server/logger.js
+++ b/server/logger.js
@@ -2,16 +2,18 @@ const Logger = require('blgr');
 
 const loadConfig = require('./utils/loadConfig');
 
-const config = loadConfig('bpanel');
+function createLogger(_config) {
+  let config = _config;
+  if (!config) config = loadConfig('bpanel');
 
-const logger = new Logger();
-logger.set({
-  filename: config.bool('log-file') ? config.location('debug.log') : null,
-  level: config.str('log-level', 'debug'),
-  console: config.bool('log-console', true),
-  shrink: config.bool('log-shrink', true)
-});
+  const logger = new Logger();
+  logger.set({
+    filename: config.bool('log-file') ? config.location('debug.log') : null,
+    level: config.str('log-level', 'debug'),
+    console: config.bool('log-console', true),
+    shrink: config.bool('log-shrink', true)
+  });
+  return logger;
+}
 
-logger.open();
-
-module.exports = logger;
+module.exports.createLogger = createLogger;

--- a/server/logger.js
+++ b/server/logger.js
@@ -1,10 +1,13 @@
 const Logger = require('blgr');
+const Config = require('bcfg');
+const assert = require('bsert');
 
 const loadConfig = require('./utils/loadConfig');
 
 function createLogger(_config) {
   let config = _config;
   if (!config) config = loadConfig('bpanel');
+  assert(config instanceof Config, 'Must pass Bcfg object to create logger');
 
   const logger = new Logger();
   logger.set({

--- a/server/logger.js
+++ b/server/logger.js
@@ -1,4 +1,4 @@
-const winston = require('winston');
+const blgr = require('blgr');
 const fs = require('bfile');
 
 /** Configure the logger */
@@ -9,31 +9,15 @@ if (!fs.existsSync(logDir)) {
   fs.mkdirSync(logDir);
 }
 
-const logger = new winston.Logger({
-  transports: [
-    new winston.transports.File({
-      level: env === 'development' ? 'debug' : 'info',
-      filename: logDir.concat('/logs.log'),
-      handleExceptions: true,
-      json: true,
-      maxsize: 5242880, // 5MB
-      maxFiles: 5,
-      colorize: false
-    }),
-    new winston.transports.Console({
-      level: 'debug',
-      handleExceptions: true,
-      json: false,
-      colorize: true
-    })
-  ],
-  exitOnError: false
+const logger = new blgr();
+logger.set({
+  level: env === 'development' ? 'debug' : 'info',
+  colors: true,
+  filename: logDir.concat('/logs.log')
 });
 
-/*
-  Stream is used to allow morgan to style console output
-  in server.js
-*/
+logger.open();
+
 module.exports = logger;
 module.exports.stream = {
   write: message => logger.info(message)

--- a/server/logger.js
+++ b/server/logger.js
@@ -1,24 +1,17 @@
-const blgr = require('blgr');
-const fs = require('bfile');
+const Logger = require('blgr');
 
-/** Configure the logger */
-const logDir = __dirname.concat('/../logs');
-const env = process.env.NODE_ENV || 'development';
+const loadConfig = require('./utils/loadConfig');
 
-if (!fs.existsSync(logDir)) {
-  fs.mkdirSync(logDir);
-}
+const config = loadConfig('bpanel');
 
-const logger = new blgr();
+const logger = new Logger();
 logger.set({
-  level: env === 'development' ? 'debug' : 'info',
-  colors: true,
-  filename: logDir.concat('/logs.log')
+  filename: config.bool('log-file') ? config.location('debug.log') : null,
+  level: config.str('log-level', 'debug'),
+  console: config.bool('log-console', true),
+  shrink: config.bool('log-shrink', true)
 });
 
 logger.open();
 
 module.exports = logger;
-module.exports.stream = {
-  write: message => logger.info(message)
-};

--- a/server/logger.js
+++ b/server/logger.js
@@ -9,7 +9,7 @@ function createLogger(_config) {
   const logger = new Logger();
   logger.set({
     filename: config.bool('log-file') ? config.location('debug.log') : null,
-    level: config.str('log-level', 'debug'),
+    level: config.str('log-level', 'info'),
     console: config.bool('log-console', true),
     shrink: config.bool('log-shrink', true)
   });

--- a/server/test/configHelpers-test.js
+++ b/server/test/configHelpers-test.js
@@ -4,7 +4,6 @@ const fs = require('bfile');
 const os = require('os');
 const { resolve } = require('path');
 
-const logger = require('../logger');
 const { initFullNode } = require('./utils/regtest');
 
 const { configHelpers } = require('../utils');
@@ -23,12 +22,12 @@ process.env.BPANEL_CLIENTS_DIR = 'test_clients';
 const { BPANEL_PREFIX, BPANEL_CLIENTS_DIR } = process.env;
 const clientsDirPath = resolve(BPANEL_PREFIX, BPANEL_CLIENTS_DIR);
 
-describe.only('configHelpers', () => {
+describe('configHelpers', () => {
   let node, apiKey, ports, options, id, config;
 
   before('create and start regtest node', async () => {
-    logger.transports.console.level = 'error';
-    logger.transports.file.level = 'error';
+    process.env.BPANEL_LOG_LEVEL = 'error';
+
     id = 'test';
     apiKey = 'foo';
     ports = {

--- a/server/utils/attach.js
+++ b/server/utils/attach.js
@@ -21,9 +21,7 @@ function attach(app, endpoint) {
       break;
     default:
       throw new Error(
-        `Unrecognized endpoint method ${endpoint.method} for path ${
-          endpoint.path
-        }`
+        `Unrecognized endpoint method ${endpoint.method} for path ${endpoint.path}`
       );
   }
 }

--- a/server/utils/clients.js
+++ b/server/utils/clients.js
@@ -40,7 +40,7 @@ function clientFactory(config) {
 
   // bitcoin, bitcoincash, handshake
   if (!config.str('chain'))
-    logger.warn(
+    logger.warning(
       `No chain set in configs for ${config.str('id')}, defaulting to 'bitcoin'`
     );
 

--- a/server/utils/clients.js
+++ b/server/utils/clients.js
@@ -1,4 +1,6 @@
 const { parse: urlParse } = require('url');
+const assert = require('bsert');
+const Config = require('bcfg');
 const { Network: BNetwork } = require('bcoin');
 const { Network: HSNetwork } = require('hsd');
 const {
@@ -10,17 +12,11 @@ const {
   WalletClient: HSWalletClient
 } = require('hs-client');
 const MultisigClient = require('bmultisig/lib/client');
-const assert = require('assert');
-const Config = require('bcfg');
-
-const logger = require('../logger');
 
 const logClientInfo = (id, type, { ssl, host, port, network }) =>
-  logger.info(
-    `${id}: Configuring ${type} client with uri: ${ssl
-      ? 'https'
-      : 'http'}://${host}:${port}, network: ${network}`
-  );
+  `${id}: Configuring ${type} client with uri: ${ssl
+    ? 'https'
+    : 'http'}://${host}:${port}, network: ${network}`;
 
 /*
  * Create clients based on given configs
@@ -34,6 +30,9 @@ function clientFactory(config) {
     config instanceof Config,
     'Must pass instance of Config class to client composer'
   );
+
+  const logger = config.obj('logger');
+  assert(logger, 'No logger attached to config');
 
   const id = config.str('id');
   assert(id, 'Client config must have an id');
@@ -116,14 +115,17 @@ function clientFactory(config) {
   // if false, do not instantiate new node client
   if (config.bool('node', true)) {
     nodeClient = new NodeClient(nodeOptions);
-    logClientInfo(id, 'node', nodeOptions);
+    const statement = logClientInfo(id, 'node', nodeOptions);
+    logger.info(statement);
   }
 
   // check if config explicitly sets wallet config to `false`
   // if false, do not instantiate new wallet client
   if (config.bool('wallet', true)) {
     walletClient = new WalletClient(walletOptions);
-    logClientInfo(id, 'wallet', walletOptions);
+
+    const statement = logClientInfo(id, 'wallet', walletOptions);
+    logger.info(statement);
   }
 
   if (config.bool('multisig', true)) {
@@ -131,7 +133,8 @@ function clientFactory(config) {
       ...walletOptions,
       multisigPath: '/'
     });
-    logClientInfo(id, 'multisig wallet', walletOptions);
+    const statement = logClientInfo(id, 'multisig wallet', walletOptions);
+    logger.info(statement);
   }
 
   return { nodeClient, walletClient, multisigClient };
@@ -144,6 +147,9 @@ function clientFactory(config) {
  */
 function buildClients(config) {
   const { loadClientConfigs, createConfigsMap } = require('./configs');
+  assert(config.has('logger'), 'Config missing logger');
+  const logger = config.obj('logger');
+
   // loadConfigs uses the bpanelConfig to find the clients and build
   // each of their configs.
   const clientConfigs = loadClientConfigs(config);
@@ -151,6 +157,10 @@ function buildClients(config) {
   const clients = clientConfigs.reduce((clientsMap, cfg) => {
     const id = cfg.str('id');
     assert(id, 'client config must have id');
+
+    // give client config the app logger
+    cfg.set('logger', logger);
+
     clientsMap.set(id, { ...clientFactory(cfg), config: cfg });
     return clientsMap;
   }, new Map());

--- a/server/utils/configs.js
+++ b/server/utils/configs.js
@@ -35,7 +35,7 @@ function loadClientConfigs(_config) {
 
   // if not passed bcfg object, create one
   if (!(_config instanceof Config)) config = loadConfig('bpanel', _config);
-  const logger = config.obj('logger');
+  const _logger = config.obj('logger');
 
   // clientsDir is the folder where all client configs
   // should be saved and can be changed w/ custom configs
@@ -55,17 +55,17 @@ function loadClientConfigs(_config) {
 
   // cancel startup process if there are no clientConfigs
   if (!files.length) {
-    logger.warning(
+    _logger.warning(
       'No client configs found. Add one manually to your clients directory \
 or use the connection-manager plugin to add via the UI'
     );
-    logger.warning(
+    _logger.warning(
       'Visit the documentation for more information: https://bpanel.org/docs/configuration.html'
     );
     return files;
   }
 
-  logger.info('Loading configs for %s clients...', files.length);
+  _logger.info('Loading configs for %s clients...', files.length);
   return files.map(fileName => {
     // After filter, we load bcfg object for each client
 
@@ -116,7 +116,7 @@ function getConfig(id) {
 
 /*
  * create and test clients based on a passed config
- * @param {Config} clientConfig
+ * @param {Bcfg | Object} options
  * @throws {ClientErrors} - throws if at least one client fails
  * @returns {[bool, ClientErrors]} [err, ClientErrors] - bool is true
  * if there was an error, false if no error.
@@ -142,6 +142,7 @@ async function testConfigOptions(options) {
   if (!pkg.chains.includes(chain))
     throw new Error(`${chain} is not a recognized chain`);
 
+  if (!clientConfig.has('logger')) clientConfig.set('logger', logger);
   const clients = clientFactory(clientConfig);
 
   // save the async checks in an array so we can parallelize the
@@ -255,7 +256,7 @@ function createConfigsMap(configs) {
  * can't connect
  * @returns {bcfg.Config}
  */
-async function createClientConfig(id, options = {}, force = false) {
+async function createClientConfig(id, options = {}, force = false, _logger) {
   assert(typeof id === 'string', 'Must pass an id as first paramater');
 
   let clientConfig = options;
@@ -272,8 +273,8 @@ async function createClientConfig(id, options = {}, force = false) {
   const [err, clientErrors] = await testConfigOptions(clientConfig);
   assert(typeof force === 'boolean', 'The force argument must be a bool.');
   if (err && force) {
-    logger.warning(clientErrors.message);
-    logger.warning('Creating config file anyway...');
+    _logger.warning(clientErrors.message);
+    _logger.warning('Creating config file anyway...');
   } else if (err) {
     throw clientErrors;
   }
@@ -288,7 +289,7 @@ async function createClientConfig(id, options = {}, force = false) {
     configTxt = configTxt.concat(text);
   }
   if (!fs.existsSync(clientsPath)) {
-    logger.warning(
+    _logger.warning(
       'Could not find requested client directory at %s. Creating new one...',
       clientsPath
     );

--- a/server/utils/configs.js
+++ b/server/utils/configs.js
@@ -79,11 +79,11 @@ function loadClientConfigs(_config) {
 
   // cancel startup process if there are no clientConfigs
   if (!files.length) {
-    logger.warn(
+    logger.warning(
       'No client configs found. Add one manually to your clients directory \
 or use the connection-manager plugin to add via the UI'
     );
-    logger.warn(
+    logger.warning(
       'Visit the documentation for more information: https://bpanel.org/docs/configuration.html'
     );
     return files;
@@ -243,7 +243,7 @@ function getDefaultConfig(bpanelConfig) {
   );
 
   if (!defaultClientConfig) {
-    logger.warn(
+    logger.warning(
       'Could not find config for %s. Will set to "default" instead.',
       bpanelConfig.str('client-id')
     );
@@ -251,9 +251,9 @@ function getDefaultConfig(bpanelConfig) {
       cfg => cfg.str('id') === 'default'
     );
     if (!defaultClientConfig) {
-      logger.warn('Could not find default client config.');
+      logger.warning('Could not find default client config.');
       defaultClientConfig = clientConfigs[0];
-      logger.warn(`Setting fallback to ${defaultClientConfig.str('id')}.`);
+      logger.warning(`Setting fallback to ${defaultClientConfig.str('id')}.`);
     }
   }
   return defaultClientConfig;
@@ -296,8 +296,8 @@ async function createClientConfig(id, options = {}, force = false) {
   const [err, clientErrors] = await testConfigOptions(clientConfig);
   assert(typeof force === 'boolean', 'The force argument must be a bool.');
   if (err && force) {
-    logger.warn(clientErrors.message);
-    logger.warn('Creating config file anyway...');
+    logger.warning(clientErrors.message);
+    logger.warning('Creating config file anyway...');
   } else if (err) {
     throw clientErrors;
   }
@@ -312,7 +312,7 @@ async function createClientConfig(id, options = {}, force = false) {
     configTxt = configTxt.concat(text);
   }
   if (!fs.existsSync(clientsPath)) {
-    logger.warn(
+    logger.warning(
       'Could not find requested client directory at %s. Creating new one...',
       clientsPath
     );

--- a/server/utils/configs.js
+++ b/server/utils/configs.js
@@ -198,7 +198,7 @@ async function getDefaultConfig(bpanelConfig) {
     cfg => cfg.str('id') === bpanelConfig.str('client-id', 'default')
   );
 
-  const logger = defaultClientConfig.obj('logger');
+  const logger = bpanelConfig.obj('logger');
 
   if (!defaultClientConfig) {
     logger.warning(

--- a/server/utils/configs.js
+++ b/server/utils/configs.js
@@ -6,20 +6,8 @@ const { resolve, parse, join } = require('path');
 const Config = require('bcfg');
 
 const pkg = require('../../pkg');
-const logger = require('../logger');
 const { clientFactory } = require('./clients');
 const loadConfig = require('./loadConfig');
-
-function getConfigFromOptions(options) {
-  if (!(options instanceof Config)) options = loadConfig(options.id, options);
-  assert(options.str('id'), 'must pass an id to test config options');
-  // making a copy from options and data properties
-  // to avoid any mutations
-  return loadConfig(options.str('id'), {
-    ...options.options,
-    ...options.data
-  });
-}
 
 /*
  * Get an array of configs for each client
@@ -35,7 +23,7 @@ function loadClientConfigs(_config) {
 
   // if not passed bcfg object, create one
   if (!(_config instanceof Config)) config = loadConfig('bpanel', _config);
-  const _logger = config.obj('logger');
+  const logger = config.obj('logger');
 
   // clientsDir is the folder where all client configs
   // should be saved and can be changed w/ custom configs
@@ -55,17 +43,17 @@ function loadClientConfigs(_config) {
 
   // cancel startup process if there are no clientConfigs
   if (!files.length) {
-    _logger.warning(
+    logger.warning(
       'No client configs found. Add one manually to your clients directory \
 or use the connection-manager plugin to add via the UI'
     );
-    _logger.warning(
+    logger.warning(
       'Visit the documentation for more information: https://bpanel.org/docs/configuration.html'
     );
     return files;
   }
 
-  _logger.info('Loading configs for %s clients...', files.length);
+  logger.info('Loading configs for %s clients...', files.length);
   return files.map(fileName => {
     // After filter, we load bcfg object for each client
 
@@ -116,19 +104,14 @@ function getConfig(id) {
 
 /*
  * create and test clients based on a passed config
- * @param {Bcfg | Object} options
+ * @param {Bcfg} config
  * @throws {ClientErrors} - throws if at least one client fails
  * @returns {[bool, ClientErrors]} [err, ClientErrors] - bool is true
  * if there was an error, false if no error.
  */
 
-async function testConfigOptions(options) {
-  let clientConfig;
-  try {
-    clientConfig = getConfigFromOptions(options);
-  } catch (e) {
-    throw e;
-  }
+async function testConfigOptions(config) {
+  assert(config instanceof Config, 'Must pass a bcfg object to test configs');
 
   const agents = new Map([
     ['bcoin', 'bitcoin'],
@@ -137,13 +120,13 @@ async function testConfigOptions(options) {
   ]);
 
   const clientErrors = new ClientErrors();
-  const chain = clientConfig.str('chain', 'bitcoin');
+  const chain = config.str('chain', 'bitcoin');
 
   if (!pkg.chains.includes(chain))
     throw new Error(`${chain} is not a recognized chain`);
 
-  if (!clientConfig.has('logger')) clientConfig.set('logger', logger);
-  const clients = clientFactory(clientConfig);
+  const logger = config.obj('logger');
+  const clients = clientFactory(config);
 
   // save the async checks in an array so we can parallelize the
   // network call with a `Promise.all`
@@ -157,8 +140,8 @@ async function testConfigOptions(options) {
     const type = key.substr(0, key.indexOf('Client'));
     const check = new Promise(async resolve => {
       try {
-        logger.info(`Checking ${key} for config "${clientConfig.str('id')}"`);
-        if (clientConfig.bool(type, true)) {
+        logger.info(`Checking ${key} for config "${config.str('id')}"`);
+        if (config.bool(type, true)) {
           const info = await clients[key].getInfo();
           if (info) {
             const { pool: { agent } } = info;
@@ -174,11 +157,7 @@ async function testConfigOptions(options) {
           }
         }
       } catch (e) {
-        logger.info(
-          '%s connection for "%s" failed.',
-          key,
-          clientConfig.str('id')
-        );
+        logger.info('%s connection for "%s" failed.', key, config.str('id'));
         clientErrors.addFailed(type, e);
       } finally {
         // resolving all calls so that we can store the failures in the
@@ -206,7 +185,7 @@ async function testConfigOptions(options) {
  * @returns {Config}
  */
 
-function getDefaultConfig(bpanelConfig) {
+async function getDefaultConfig(bpanelConfig) {
   assert(
     bpanelConfig instanceof Config,
     'Need the main bcfg for the app to get default configs'
@@ -218,6 +197,8 @@ function getDefaultConfig(bpanelConfig) {
   let defaultClientConfig = clientConfigs.find(
     cfg => cfg.str('id') === bpanelConfig.str('client-id', 'default')
   );
+
+  const logger = defaultClientConfig.obj('logger');
 
   if (!defaultClientConfig) {
     logger.warning(
@@ -256,47 +237,46 @@ function createConfigsMap(configs) {
  * can't connect
  * @returns {bcfg.Config}
  */
-async function createClientConfig(id, options = {}, force = false, _logger) {
-  assert(typeof id === 'string', 'Must pass an id as first paramater');
+async function createClientConfig(config, force = false) {
+  assert(config instanceof Config, 'Must pass bcfg config to create client');
+  assert(config.has('id'), 'Config must have an id set');
 
-  let clientConfig = options;
-  if (!(options instanceof Config))
-    clientConfig = getConfigFromOptions({ id, ...options });
+  const logger = config.obj('logger');
 
-  const appConfig = loadConfig('bpanel', options);
+  const appConfig = loadConfig('bpanel');
   const clientsDir = appConfig.str('clients-dir', 'clients');
 
   // get full path to client configs relative to the project
   // prefix which defaults to `~/.bpanel`
   const clientsPath = resolve(appConfig.prefix, clientsDir);
 
-  const [err, clientErrors] = await testConfigOptions(clientConfig);
+  const [err, clientErrors] = await testConfigOptions(config);
   assert(typeof force === 'boolean', 'The force argument must be a bool.');
   if (err && force) {
-    _logger.warning(clientErrors.message);
-    _logger.warning('Creating config file anyway...');
+    logger.warning(clientErrors.message);
+    logger.warning('Creating config file anyway...');
   } else if (err) {
     throw clientErrors;
   }
 
   let configTxt = '';
-  for (let key in clientConfig.options) {
+  for (let key in config.options) {
     const configKey = key
       .replace('-', '')
       .replace('_', '')
       .toLowerCase();
-    const text = `${configKey}: ${clientConfig.options[key]}\n`;
+    const text = `${configKey}: ${config.options[key]}\n`;
     configTxt = configTxt.concat(text);
   }
   if (!fs.existsSync(clientsPath)) {
-    _logger.warning(
+    logger.warning(
       'Could not find requested client directory at %s. Creating new one...',
       clientsPath
     );
     fs.mkdirpSync(clientsPath);
   }
-  fs.writeFileSync(`${clientsPath}/${clientConfig.str('id')}.conf`, configTxt);
-  return clientConfig;
+  fs.writeFileSync(`${clientsPath}/${config.str('id')}.conf`, configTxt);
+  return config;
 }
 
 class ClientErrors extends Error {
@@ -323,12 +303,11 @@ class ClientErrors extends Error {
 
 module.exports = {
   createClientConfig,
-  loadConfig,
-  getConfigFromOptions,
-  loadClientConfigs,
   createConfigsMap,
-  getDefaultConfig,
   getConfig,
+  getDefaultConfig,
+  loadConfig,
+  loadClientConfigs,
   ClientErrors,
   testConfigOptions
 };

--- a/server/utils/configs.js
+++ b/server/utils/configs.js
@@ -35,6 +35,7 @@ function loadClientConfigs(_config) {
 
   // if not passed bcfg object, create one
   if (!(_config instanceof Config)) config = loadConfig('bpanel', _config);
+  const logger = config.obj('logger');
 
   // clientsDir is the folder where all client configs
   // should be saved and can be changed w/ custom configs

--- a/server/utils/configs.js
+++ b/server/utils/configs.js
@@ -7,33 +7,8 @@ const Config = require('bcfg');
 
 const pkg = require('../../pkg');
 const logger = require('../logger');
-const { clientFactory } = require('../utils/clients');
-
-/*
- * Load up a bcfg object for a given module and set of options
- * @params {string} - name - module name
- * @params {object} - [options] - optional options object to inject into config
- * @returns {Config} - returns a bcfg object
- */
-function loadConfig(name, options = {}) {
-  assert(typeof name === 'string', 'Must pass a name to load config');
-  const config = new Config(name);
-
-  // load any custom configs being passed in
-  config.inject(options);
-
-  config.load({
-    env: true
-  });
-
-  if (name === 'bpanel') {
-    config.load({
-      argv: true
-    });
-  }
-
-  return config;
-}
+const { clientFactory } = require('./clients');
+const loadConfig = require('./loadConfig');
 
 function getConfigFromOptions(options) {
   if (!(options instanceof Config)) options = loadConfig(options.id, options);

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -4,11 +4,12 @@
  * @module server-utils
  */
 
-exports.npmExists = require('./npm-exists');
 exports.configHelpers = require('./configs');
 exports.clientFactory = require('./clients').clientFactory;
 exports.buildClients = require('./clients').buildClients;
 exports.clientHelpers = require('./clients');
 exports.attach = require('./attach');
+exports.loadConfig = require('./loadConfig');
 exports.apiFilters = require('./apiFilters');
 exports.pluginUtils = require('./plugins');
+exports.npmExists = require('./npm-exists');

--- a/server/utils/loadConfig.js
+++ b/server/utils/loadConfig.js
@@ -1,0 +1,37 @@
+const assert = require('bsert');
+const fs = require('bfile');
+const Config = require('bcfg');
+
+/*
+ * Load up a bcfg object for a given module and set of options
+ * @params {string} - name - module name
+ * @params {object} - [options] - optional options object to inject into config
+ * @returns {Config} - returns a bcfg object
+ */
+function loadConfig(name, options = {}) {
+  assert(typeof name === 'string', 'Must pass a name to load config');
+  const config = new Config(name);
+
+  // load any custom configs being passed in
+  config.inject(options);
+
+  config.load({
+    env: true
+  });
+
+  if (name === 'bpanel') {
+    config.load({
+      argv: true
+    });
+
+    const configFile = config.location('config.js');
+    if (fs.existsSync(configFile)) {
+      const fileOptions = require(configFile);
+      config.inject(fileOptions);
+    }
+  }
+
+  return config;
+}
+
+module.exports = loadConfig;


### PR DESCRIPTION
Built off of #159 

Includes:
- fixes to tests
- removes use of logger in webpack 
-  attaches a logger to the main app config created in server/index.js. Since the logger.js file isn't async  creates a new instance every time, ideally we only have one instance of the logger which is what is attached to the main config. It would be better to have the server structured more like in bcoin so it is passed through as options, but hopefully this can work for now
- loggers now use the app's main config so that users can pass through logging options
- some refactoring for readability and also to help fix bugs that came up with this new system 