### PR TITLE
start with settings and connection-manager plugins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       _DOCKER_NODE_HOST: bcoin
       # Edit this to add/remove plugins! This cannot be edited after startup
       # even with bpanel's config.js. Must edit below, and rebuild container.
-      BPANEL_PLUGINS: '@bpanel/genesis-theme,@bpanel/bui,@bpanel/connection-manager'
+      BPANEL_PLUGINS: '@bpanel/genesis-theme,@bpanel/connection-manager'
     ports:
       - "5000:5000"
       - "5001:5001"

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -16,7 +16,7 @@ const CLIENTS_DIR = path.resolve(BPANEL_DIR, 'clients');
 const LOCAL_PLUGINS_DIR = path.resolve(BPANEL_DIR, 'local_plugins');
 
 const configText = `module.exports = {
-  plugins: ['@bpanel/genesis-theme', '@bpanel/bui', '@bpanel/settings', '@bpanel/connection-manager'],
+  plugins: ['@bpanel/genesis-theme', '@bpanel/settings', '@bpanel/connection-manager'],
   localPlugins: [],
 }`;
 

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -16,7 +16,7 @@ const CLIENTS_DIR = path.resolve(BPANEL_DIR, 'clients');
 const LOCAL_PLUGINS_DIR = path.resolve(BPANEL_DIR, 'local_plugins');
 
 const configText = `module.exports = {
-  plugins: ['@bpanel/genesis-theme', '@bpanel/bui'],
+  plugins: ['@bpanel/genesis-theme', '@bpanel/bui', '@bpanel/settings', '@bpanel/connection-manager'],
   localPlugins: [],
 }`;
 


### PR DESCRIPTION
Simple update to start new installs with the connection manager and settings (especially good for setting up new environments).