### PR TITLE
docker: bcoin-init: funded-dummy-wallets: mining on regtest is OK

### DIFF
--- a/scripts/funded-dummy-wallets.js
+++ b/scripts/funded-dummy-wallets.js
@@ -8,7 +8,7 @@ const makeWallets = async (node, config, logger, wallet) => {
   const miner = node.miner;
   const chain = node.chain;
 
-  if (network === 'main' || network === 'regtest')
+  if (network === 'main' || network === 'testnet')
     logger.warning(
       `You probably don't want to be running the miner on the ${network} network. Mining
 on a production network can seriously impact performance of your host machine and is generally


### PR DESCRIPTION
This warning gets kinda buried in the bcoin output but I noticed it watching
`docker logs bpanel_bcoin_1 -f` and thought it was kinda funny :-)