### PR TITLE
bcoin wallet pagination test: docker container and init script

### DIFF
--- a/Dockerfile-bcoin
+++ b/Dockerfile-bcoin
@@ -14,14 +14,14 @@ FROM base AS build
 RUN pacman -Syu --noconfirm base-devel unrar git python2 \
     && ln -s /usr/bin/python2 /usr/bin/python
 
-ARG branch=master
+ARG repo=bcoin-org/bcoin
 
 # use this to bust the build cache
 ARG rebuild=0
 
 # Install bcoin, bmultisig, blgr, bclient
 RUN npm init -y &>/dev/null \
-  && npm install bcoin-org/bcoin \
+  && npm install $repo \
   bcoin-org/bmultisig \
   bcoin-org/blgr \
   bcoin-org/bclient

--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-### This is a dev branch only. Rebuilding the `bcoin` docker image will be required:
-```
-$ docker-compose build bcoin
-$ docker-compose up -d
-```
-
-
 # Welcome to bPanel!
 
 This is the official repo for the [bPanel project](https://bpanel.org),

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+### This is a dev branch only. Rebuilding the `bcoin` docker image will be required:
+```
+$ docker-compose build bcoin
+$ docker-compose up -d
+```
+
+
 # Welcome to bPanel!
 
 This is the official repo for the [bPanel project](https://bpanel.org),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,13 +50,12 @@ services:
     ## Use image to to pull from docker hub
     image: bpanel/bcoin:dev
     ## Build to use local Dockerfile-bcoin
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile-bcoin
-    #   args:
-    #     repo: https://github.com/bcoin-org/bcoin.git
-    #     branch: master
-    #     rebuild: 0
+    build:
+      context: .
+      dockerfile: Dockerfile-bcoin
+      args:
+        repo: braydonf/bcoin#wallet-pagination
+        rebuild: 0
     restart: unless-stopped
     env_file:
       # Set arguments to use in bcoin-init.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ volumes:
   certs:
   bcoin:
   configs:
-    #driver_opts:
-    #  type: none
-    #  device: $HOME/.bpanel
-    #  o: bind
+    driver_opts:
+      type: none
+      device: $HOME/.bpanel
+      o: bind

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       context: .
       dockerfile: Dockerfile-bcoin
       args:
-        repo: pinheadmz/bcoin#wallet-pagination-zip
+        repo: bpanel-org/bcoin#experimental
         rebuild: 0
     restart: unless-stopped
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,14 +48,14 @@ services:
 
   bcoin:
     ## Use image to to pull from docker hub
-    image: bpanel/bcoin:dev
+    image: bpanel/bcoin:experimental
     ## Build to use local Dockerfile-bcoin
-    build:
-      context: .
-      dockerfile: Dockerfile-bcoin
-      args:
-        repo: bpanel-org/bcoin#experimental
-        rebuild: 0
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile-bcoin
+    #   args:
+    #     repo: bpanel-org/bcoin#experimental
+    #     rebuild: 0
     restart: unless-stopped
     env_file:
       # Set arguments to use in bcoin-init.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ volumes:
   certs:
   bcoin:
   configs:
-    driver_opts:
-      type: none
-      device: $HOME/.bpanel
-      o: bind
+    #driver_opts:
+    #  type: none
+    #  device: $HOME/.bpanel
+    #  o: bind

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       context: .
       dockerfile: Dockerfile-bcoin
       args:
-        repo: braydonf/bcoin#wallet-pagination
+        repo: pinheadmz/bcoin#wallet-pagination-zip
         rebuild: 0
     restart: unless-stopped
     env_file:

--- a/etc/regtest.bcoin.env
+++ b/etc/regtest.bcoin.env
@@ -12,4 +12,4 @@ BCOIN_NO_WALLET=true
 BCOIN_INDEX_TX=true
 BCOIN_INDEX_ADDRESS=true
 BCOIN_NODE_HOST=0.0.0.0
-BCOIN_INIT_SCRIPT=funded-dummy-wallets.js
+BCOIN_INIT_SCRIPT=pagination-test-wallets.js

--- a/etc/regtest.bcoin.env
+++ b/etc/regtest.bcoin.env
@@ -12,8 +12,4 @@ BCOIN_NO_WALLET=true
 BCOIN_INDEX_TX=true
 BCOIN_INDEX_ADDRESS=true
 BCOIN_NODE_HOST=0.0.0.0
-
-# init scripts: uncomment ONE to run after bcoin node and wallet are opened
-# or substitute with your own custom init script saved to the /scripts directory
-#BCOIN_INIT_SCRIPT=funded-dummy-wallets.js
 BCOIN_INIT_SCRIPT=pagination-test-wallets.js

--- a/etc/regtest.bcoin.env
+++ b/etc/regtest.bcoin.env
@@ -12,4 +12,7 @@ BCOIN_NO_WALLET=true
 BCOIN_INDEX_TX=true
 BCOIN_INDEX_ADDRESS=true
 BCOIN_NODE_HOST=0.0.0.0
+
+# init scripts: uncomment ONE to run after node and wallet are opened
+#BCOIN_INIT_SCRIPT=funded-dummy-wallets.js
 BCOIN_INIT_SCRIPT=pagination-test-wallets.js

--- a/etc/regtest.bcoin.env
+++ b/etc/regtest.bcoin.env
@@ -13,6 +13,7 @@ BCOIN_INDEX_TX=true
 BCOIN_INDEX_ADDRESS=true
 BCOIN_NODE_HOST=0.0.0.0
 
-# init scripts: uncomment ONE to run after node and wallet are opened
+# init scripts: uncomment ONE to run after bcoin node and wallet are opened
+# or substitute with your own custom init script saved to the /scripts directory
 #BCOIN_INIT_SCRIPT=funded-dummy-wallets.js
 BCOIN_INIT_SCRIPT=pagination-test-wallets.js

--- a/scripts/funded-dummy-wallets.js
+++ b/scripts/funded-dummy-wallets.js
@@ -1,4 +1,4 @@
-const { protocol: consensus } = require('bcoin');
+const { protocol: { consensus } } = require('bcoin');
 
 const makeWallets = async (node, config, logger, wallet) => {
   const network = node.network.type;

--- a/scripts/pagination-test-wallets.js
+++ b/scripts/pagination-test-wallets.js
@@ -9,11 +9,16 @@ module.exports = async (node, config, logger, wallet) => {
   const feeRate = network.minRelay * 10; // for some reason bc segwit??!!
   const wdb = wallet.wdb;
 
-  const numInitBlocks = 144 * 3; // to activate segwit
-  const numTxBlocks = 10;
-  const numTxPerBlock = 10;
-  const maxOutputsPerTx = 4;
-  const minSend = 50000;
+  const numInitBlocks = 144 * 3;  // Initial blocks mined to activate SegWit.
+                                  // Miner primary/default then evenly disperses
+                                  // all funds to other wallet accounts
+
+  const numTxBlocks = 10;         // How many blocks to randomly fill with txs
+  const numTxPerBlock = 10;       // How many txs to try to put in each block
+  // (due to the random tx-generation, some txs will fail due to lack of funds)
+
+  const maxOutputsPerTx = 4;      // Each tx will have a random # of outputs
+  const minSend = 50000;          // Each tx output will have a random value
   const maxSend = 100000;
 
   // We are going to bend time, and start our blockchain in the past!

--- a/scripts/pagination-test-wallets.js
+++ b/scripts/pagination-test-wallets.js
@@ -64,7 +64,8 @@ module.exports = async (node, config, logger, wallet) => {
 
     for (const aName of accountNames) {
       await newWallet.createAccount({
-        name: aName
+        name: aName,
+        witness: Math.random() < 0.5
       });
     }
   }

--- a/scripts/pagination-test-wallets.js
+++ b/scripts/pagination-test-wallets.js
@@ -21,16 +21,16 @@ module.exports = async (node, config, logger, wallet) => {
   const blockInterval = 60 * 10; // ten mimnutes
 
   const walletNames = [
-    'Mark',
-    'Buck',
-    'Zip',
-    'Darren',
-    'Nodar',
-    'Javed',
-    'Boyma',
-    'Stephen',
-    'Andrew',
-    'JJ'
+    'Powell',
+    'Yellen',
+    'Bernanke',
+    'Greenspan',
+    'Volcker',
+    'Miller',
+    'Burns',
+    'Martin',
+    'McCabe',
+    'Eccles'
   ];
 
   const accountNames = ['hot', 'cold'];

--- a/scripts/pagination-test-wallets.js
+++ b/scripts/pagination-test-wallets.js
@@ -9,7 +9,7 @@ module.exports = async (node, config, logger, wallet) => {
   const feeRate = network.minRelay * 10; // for some reason bc segwit??!!
   const wdb = wallet.wdb;
 
-  const numInitBlocks = 144 * 3; //. to activate segwit
+  const numInitBlocks = 144 * 3; // to activate segwit
   const numTxBlocks = 10;
   const numTxPerBlock = 10;
   const maxOutputsPerTx = 4;
@@ -112,7 +112,7 @@ module.exports = async (node, config, logger, wallet) => {
   logger.info('Creating a big mess!...');
   for (let b = 0; b < numTxBlocks; b++) {
     for (let t = 0; t < numTxPerBlock; t++) {
-      // TO
+      // Randomly select reicipents for this tx
       const outputs = [];
       const numOutputs = Math.floor(Math.random() * maxOutputsPerTx) + 1;
       for (let o = 0; o < numOutputs; o++) {
@@ -130,7 +130,7 @@ module.exports = async (node, config, logger, wallet) => {
         });
       }
 
-      // FROM
+      // Randomly choose a sender for this tx
       const sendWallet = wallets[Math.floor(Math.random() * wallets.length)];
       const sendAcct = accountNames[Math.floor(Math.random() * wallets.length)];
       try {

--- a/scripts/pagination-test-wallets.js
+++ b/scripts/pagination-test-wallets.js
@@ -1,0 +1,103 @@
+const { protocol: { consensus } } = require('bcoin');
+
+module.exports = async (node, config, logger, wallet) => {
+  consensus.COINBASE_MATURITY = 0;
+
+  const miner = node.miner;
+  const chain = node.chain;
+  const network = node.network;
+  const feeRate = network.minRelay;
+  const wdb = wallet.wdb;
+
+  const numBlocks = 1;
+
+  const walletNames = [
+    'Mark',
+    'Buck',
+    'Zip',
+    'Darren',
+    'Nodar',
+    'Javed',
+    'Boyma',
+    'Stephen',
+    'Andrew',
+    'JJ'
+  ];
+
+  const accountNames = [
+    'candy',
+    'games',
+    'rent',
+    'clothes',
+    'food',
+    'taxes',
+    'furniture',
+    'travel',
+    'gifts'
+  ];
+
+  const wallets = [];
+
+  logger.info('Creating wallets and accounts...');
+  for (const wName of walletNames) {
+    const newWallet = await wdb.create({
+      id: wName,
+      witness: Math.random() < 0.5
+    });
+
+    wallets.push(newWallet);
+
+    for (const aName of accountNames) {
+      await newWallet.createAccount({
+        name: aName
+      });
+    }
+  }
+  accountNames.push('default');
+
+  logger.info('Mining blocks...');
+  const primary = wdb.primary;
+  const minerReceive = await primary.receiveAddress();
+  await miner.addAddress(minerReceive);
+  for (let i = 0; i < numBlocks; i++) {
+    const entry = await chain.getEntry(node.chain.tip.hash);
+    const block = await miner.mineBlock(entry, minerReceive);
+    await node.chain.add(block);
+  }
+
+  logger.info('Ensure wallet is caught up before proceeding...');
+  await wdb.rescan(0);
+
+  logger.info('Air-dropping funds to the people...');
+  const balance = await primary.getBalance(0);
+
+  const totalAmt = balance.confirmed;
+  const amtPerAcct = totalAmt / (walletNames.length * accountNames.length);
+  console.log('1', balance, totalAmt, amtPerAcct);
+
+  const outputs = [];
+  for (const wallet of wallets) {
+    for (const aName of accountNames) {
+      const recAddr = await wallet.receiveAddress(aName);
+      outputs.push({
+        value: amtPerAcct,
+        address: recAddr
+      });
+    }
+  }
+
+  console.log('2', balance, totalAmt, amtPerAcct);
+
+  await primary.send({
+    outputs: outputs,
+    rate: feeRate,
+    subtractFee: true
+  });
+
+  logger.info('Confirming airdrop...');
+  {
+    const entry = await chain.getEntry(node.chain.tip.hash);
+    const block = await miner.mineBlock(entry, minerReceive);
+    await node.chain.add(block);
+  }
+};

--- a/scripts/pagination-test-wallets.js
+++ b/scripts/pagination-test-wallets.js
@@ -18,7 +18,7 @@ module.exports = async (node, config, logger, wallet) => {
 
   // We are going to bend time, and start our blockchain in the past!
   let virtualNow = network.now() - 60 * 10 * (numInitBlocks + numTxBlocks + 1);
-  const blockInterval = 60 * 10; // ten mimnutes
+  const blockInterval = 60 * 10; // ten minutes
 
   const walletNames = [
     'Powell',
@@ -112,7 +112,7 @@ module.exports = async (node, config, logger, wallet) => {
   logger.info('Creating a big mess!...');
   for (let b = 0; b < numTxBlocks; b++) {
     for (let t = 0; t < numTxPerBlock; t++) {
-      // Randomly select reicipents for this tx
+      // Randomly select recipients for this tx
       const outputs = [];
       const numOutputs = Math.floor(Math.random() * maxOutputsPerTx) + 1;
       for (let o = 0; o < numOutputs; o++) {


### PR DESCRIPTION
After checking out this branch you'll need to rebuild the bcoin container because it pulls from a different repo (my PR on Braydon's PR): https://github.com/pinheadmz/bcoin/tree/wallet-pagination-zip

```
docker-compose build bcoin
docker-compose up bcoin
```
...then run bPanel and switch to `_docker` client to access the changes.

The init script:
- Mines 144 * 3 blocks to `primary/default` to activate SegWit on the regtest chain
- Creates 10 wallets (randomly segwit or not) with 3 accounts each
- Disperses all the funds from the initial mining evenly to all accounts
- Randomly creates transactions between the accounts: Sending acct, number of outputs, receiving accts, send amount. You can see these settings in the first few lines of the init script
- Mines batches of txs into blocks

Also - and this part is especially cool :-)
Even though the script mines hundreds of blocks very quickly on launch, the _timestamps_ of these blocks are manipulated so they "appear" to be 10 minutes apart. I did this because the pagination API includes parameters for _time_, so I thought it'd be nice to be able to sort the txs by the "virtual" time they were mined.


