### PR TITLE
fix so that localhost is properly used as fallback for client factory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -661,7 +661,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "optional": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -2640,33 +2639,33 @@
       "version": "github:bcoin-org/bcoin#bd7a0949b65035c65d0effaec5f25324a178cea6",
       "from": "github:bcoin-org/bcoin",
       "requires": {
-        "bcfg": "~0.1.4",
-        "bclient": "~0.1.5",
-        "bcrypto": "~3.0.1",
-        "bdb": "~1.1.3",
-        "bdns": "~0.1.3",
-        "bevent": "~0.1.3",
-        "bfile": "~0.1.3",
-        "bfilter": "~1.0.3",
-        "bheep": "~0.1.3",
-        "binet": "~0.3.3",
-        "blgr": "~0.1.4",
-        "blru": "~0.1.4",
-        "blst": "~0.1.3",
-        "bmutex": "~0.1.4",
-        "bsert": "~0.0.7",
-        "bsip": "~0.1.4",
-        "bsock": "~0.1.4",
-        "bsocks": "~0.2.3",
-        "bstring": "~0.3.4",
-        "btcp": "~0.1.3",
-        "buffer-map": "~0.0.4",
-        "bufio": "~1.0.3",
-        "bupnp": "~0.2.4",
-        "bval": "~0.1.4",
-        "bweb": "~0.1.6",
-        "mrmr": "~0.1.4",
-        "n64": "~0.2.5"
+        "bcfg": "~0.1.5",
+        "bclient": "~0.1.6",
+        "bcrypto": "~3.0.2",
+        "bdb": "~1.1.5",
+        "bdns": "~0.1.4",
+        "bevent": "~0.1.4",
+        "bfile": "~0.1.4",
+        "bfilter": "~1.0.4",
+        "bheep": "~0.1.4",
+        "binet": "~0.3.4",
+        "blgr": "~0.1.5",
+        "blru": "~0.1.5",
+        "blst": "~0.1.4",
+        "bmutex": "~0.1.5",
+        "bsert": "~0.0.8",
+        "bsip": "~0.1.5",
+        "bsock": "~0.1.5",
+        "bsocks": "~0.2.4",
+        "bstring": "~0.3.5",
+        "btcp": "~0.1.4",
+        "buffer-map": "~0.0.5",
+        "bufio": "~1.0.4",
+        "bupnp": "~0.2.5",
+        "bval": "~0.1.5",
+        "bweb": "~0.1.7",
+        "mrmr": "~0.1.5",
+        "n64": "~0.2.6"
       },
       "dependencies": {
         "bclient": {
@@ -2822,11 +2821,18 @@
         "bsert": "~0.0.5"
       }
     },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-      "optional": true,
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -2911,10 +2917,118 @@
             "bsert": "~0.0.5"
           }
         },
+        "bcoin": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/bcoin/-/bcoin-1.0.2.tgz",
+          "integrity": "sha512-eG7j7giwjWHa6et1ZSTgqELRKOFRaQYWDdpA0AbQQO1Xw5K8nqIDPuXySwO18Y9S2Ik+VkvAqL6IlmfnYzA3mw==",
+          "requires": {
+            "bcfg": "~0.1.0",
+            "bclient": "~0.1.1",
+            "bcrypto": "~0.3.7",
+            "bdb": "~0.2.1",
+            "bdns": "~0.1.0",
+            "bevent": "~0.1.0",
+            "bfile": "~0.1.0",
+            "bfilter": "~0.2.0",
+            "bheep": "~0.1.0",
+            "binet": "~0.3.0",
+            "blgr": "~0.1.0",
+            "blru": "~0.1.0",
+            "blst": "~0.1.0",
+            "bmutex": "~0.1.0",
+            "bn.js": "~4.11.8",
+            "bsip": "~0.1.0",
+            "bsock": "~0.1.0",
+            "bsocks": "~0.2.0",
+            "bstring": "~0.1.0",
+            "btcp": "~0.1.0",
+            "bufio": "~0.2.0",
+            "bupnp": "~0.2.1",
+            "bval": "~0.1.0",
+            "bweb": "~0.1.1",
+            "mrmr": "~0.1.0",
+            "n64": "~0.2.0"
+          },
+          "dependencies": {
+            "bcrypto": {
+              "version": "0.3.7",
+              "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-0.3.7.tgz",
+              "integrity": "sha512-ZFeKszFo4abpbzLUK8sqQx87Np5ptaskhszU4Jf9JDFa1Bjuanwrv0a7z1xZJOWNG9abz8krgwvO1Z/NBtsgbg==",
+              "requires": {
+                "bindings": "~1.3.0",
+                "bn.js": "~4.11.8",
+                "bufio": "~0.2.0",
+                "elliptic": "~6.4.0",
+                "nan": "~2.10.0",
+                "secp256k1": "3.5.0"
+              }
+            },
+            "bdb": {
+              "version": "0.2.3",
+              "resolved": "https://registry.npmjs.org/bdb/-/bdb-0.2.3.tgz",
+              "integrity": "sha512-GOfUit8Rq9Y5pUuD3N4zFdZ99sXfswj7QIoFyKQnqq0zmLeQ7riJcpReJZadluOWOmQovzNij75kgA/zlKRnsw==",
+              "requires": {
+                "bsert": "~0.0.3",
+                "leveldown": "4.0.1"
+              }
+            },
+            "bstring": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/bstring/-/bstring-0.1.2.tgz",
+              "integrity": "sha512-n7FeLSrKfsPnZstqA9PfPME1apI9u9WB35aDbsubWzLz1GjpgXewCXYyq9/m8c/IB/pFXRwqs0XwL/qq5IGJPQ==",
+              "requires": {
+                "bindings": "~1.3.0",
+                "bsert": "~0.0.3",
+                "nan": "~2.10.0"
+              }
+            },
+            "bufio": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/bufio/-/bufio-0.2.0.tgz",
+              "integrity": "sha512-PjL1QglhgZCWEKWbxzlVB4ExvNorHMu0JSu4ehzeKi38R74Fp7duHAl8xNEqsbJXP5Dfym7XuSEkVol1KX5mhw=="
+            }
+          }
+        },
+        "bfilter": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/bfilter/-/bfilter-0.2.0.tgz",
+          "integrity": "sha512-kQ+LV1FTS3un6iiOqg9qp2kAF+fADZNMZpmv2DHMFIgRSCAjH4NHi9p9X3i34kGJlZzP7+KkySK5it/8/oWKEA==",
+          "requires": {
+            "bufio": "~0.2.0",
+            "mrmr": "~0.1.0"
+          },
+          "dependencies": {
+            "bufio": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/bufio/-/bufio-0.2.0.tgz",
+              "integrity": "sha512-PjL1QglhgZCWEKWbxzlVB4ExvNorHMu0JSu4ehzeKi38R74Fp7duHAl8xNEqsbJXP5Dfym7XuSEkVol1KX5mhw=="
+            }
+          }
+        },
         "bsert": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.6.tgz",
           "integrity": "sha512-Rddj7b623cGW3K4Km8mFdVVhWDfDlm2MjYCwXm8lmhqRuPLVAKylcXNk5v2+QZJP5uW4BqkA8z1C69Fp2CCbRg=="
+        },
+        "bsock": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.5.tgz",
+          "integrity": "sha512-Q41VI1jX3hVbv8NBz+/HCvJXEN2/WVeXUJzooLE69LmVdsdwbN77v0pd5Efvz5+JNASV8iESfxitvdx/uknfNQ==",
+          "requires": {
+            "bsert": "~0.0.8"
+          },
+          "dependencies": {
+            "bsert": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.8.tgz",
+              "integrity": "sha512-MzSxGNGymvJ2wAJ0lrC2cT+Irq2q+EMz5ijt8qXIxt02VoO+ZFWPNrmzNHGq6F8RJnIzzRmKz8mv1/j2xU1TQg=="
+            }
+          }
+        },
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
         }
       }
     },
@@ -2929,8 +3043,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-      "dev": true
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "bns": {
       "version": "0.6.1",
@@ -3071,8 +3184,7 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-      "dev": true
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -3084,7 +3196,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-      "dev": true,
       "requires": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -3205,14 +3316,20 @@
       "integrity": "sha512-t1qJLxMlbkn9JNmsu6RZYyv+8oomTUW/H7nXBP1X6gr9cGR9QuHTgDcyhY/mxSQ88D2HpbkJ7BjAhFcxMqn4jA==",
       "requires": {
         "babel-polyfill": "^6.26.0",
-        "bsert": "0.0.4",
-        "bsock": "github:bucko13/bsock#49a8d62abebc9316ab12b00a59d1abcfdb668c06"
+        "bsert": "0.0.4"
       },
       "dependencies": {
         "bsert": {
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.4.tgz",
           "integrity": "sha512-VReLe1aTaHRmf80YLOHUk8ONQ48SjseZP76GlNIDheD5REYByn/Mm9yrtI0/ZCaFrcfxzgpiw1/hMMCUOSMa3w=="
+        },
+        "bsock": {
+          "version": "github:bucko13/bsock#49a8d62abebc9316ab12b00a59d1abcfdb668c06",
+          "from": "github:bucko13/bsock#49a8d62abebc9316ab12b00a59d1abcfdb668c06",
+          "requires": {
+            "bsert": "~0.0.4"
+          }
         }
       }
     },
@@ -3289,8 +3406,7 @@
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-      "dev": true
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "bufio": {
       "version": "1.0.3",
@@ -3551,7 +3667,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -4039,7 +4154,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -4052,7 +4166,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -4396,7 +4509,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "optional": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -4484,8 +4596,7 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "optional": true
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
       "version": "1.1.2",
@@ -4519,8 +4630,7 @@
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "optional": true
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "di": {
       "version": "0.0.1",
@@ -4640,6 +4750,16 @@
         "is-obj": "^1.0.0"
       }
     },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -4692,7 +4812,6 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
       "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
-      "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -5351,7 +5470,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -5694,6 +5812,11 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "fast-future": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
+      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -5965,8 +6088,7 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "optional": true
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
       "version": "1.0.0",
@@ -6481,7 +6603,6 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "optional": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -6539,8 +6660,7 @@
     "github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-      "optional": true
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
     },
     "glob": {
       "version": "7.1.3",
@@ -6733,8 +6853,7 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "optional": true
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
@@ -6769,7 +6888,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -6779,7 +6897,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -6833,7 +6950,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -8087,6 +8203,65 @@
         }
       }
     },
+    "leveldown": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-4.0.1.tgz",
+      "integrity": "sha512-ZlBKVSsglPIPJnz4ggB8o2R0bxDxbsMzuQohbfgoFMVApyTE118DK5LNRG0cRju6rt3OkGxe0V6UYACGlq/byg==",
+      "requires": {
+        "abstract-leveldown": "~5.0.0",
+        "bindings": "~1.3.0",
+        "fast-future": "~1.0.2",
+        "nan": "~2.10.0",
+        "prebuild-install": "^4.0.0"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+          "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        },
+        "expand-template": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
+          "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg=="
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+        },
+        "prebuild-install": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
+          "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^1.0.2",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "node-abi": "^2.2.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "os-homedir": "^1.0.1",
+            "pump": "^2.0.1",
+            "rc": "^1.1.6",
+            "simple-get": "^2.7.0",
+            "tar-fs": "^1.13.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+          }
+        }
+      }
+    },
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -8687,7 +8862,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -8817,8 +8991,7 @@
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "optional": true
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "mini-css-extract-plugin": {
       "version": "0.4.2",
@@ -8847,14 +9020,12 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-      "dev": true
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -9130,7 +9301,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.5.1.tgz",
       "integrity": "sha512-oDbFc7vCFx0RWWCweTer3hFm1u+e60N5FtGnmRV6QqvgATGFH/XRR6vqWIeBVosCYCqt6YdIr2L0exLZuEdVcQ==",
-      "optional": true,
       "requires": {
         "semver": "^5.4.1"
       }
@@ -9267,8 +9437,7 @@
     "noop-logger": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
-      "optional": true
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
     },
     "nopt": {
       "version": "1.0.10",
@@ -9340,7 +9509,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "optional": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -11410,7 +11578,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -11519,6 +11686,21 @@
         "ajv-keywords": "^3.1.0"
       }
     },
+    "secp256k1": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
+      "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
+      "requires": {
+        "bindings": "^1.2.1",
+        "bip66": "^1.1.3",
+        "bn.js": "^4.11.3",
+        "create-hash": "^1.1.2",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.2.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -11616,7 +11798,6 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -11643,14 +11824,12 @@
     "simple-concat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-      "optional": true
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
     },
     "simple-get": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
       "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-      "optional": true,
       "requires": {
         "decompress-response": "^3.3.0",
         "once": "^1.3.1",
@@ -12423,7 +12602,6 @@
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
       "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
-      "optional": true,
       "requires": {
         "chownr": "^1.0.1",
         "mkdirp": "^0.5.1",
@@ -12435,7 +12613,6 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
           "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-          "optional": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -12447,7 +12624,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
       "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-      "optional": true,
       "requires": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
@@ -12570,8 +12746,7 @@
     "to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-      "optional": true
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -13607,14 +13782,12 @@
     "which-pm-runs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-      "optional": true
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
     },
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "optional": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }

--- a/server/utils/clients.js
+++ b/server/utils/clients.js
@@ -66,7 +66,11 @@ function clientFactory(config) {
 
   // set fallback network configs from `uri` config if set
   let port = config.int('port', network.rpcPort);
-  let hostname = config.str('node-host') || config.str('host', '127.0.0.1');
+  let hostname = 'localhost';
+  if (config.str('node-host')) hostname = config.str('node-host');
+  else if (config.str('host')) hostname = config.str('host');
+  else if (config.str('hostname')) hostname = config.str('hostname');
+
   let protocol = config.str('protocol', 'http:');
 
   let url = config.str('url') || config.str('node-uri');


### PR DESCRIPTION
If you left the host field blank when adding a config, it would create a malformed URL b/c hostname wasn't properly falling back to `127.0.0.1` or `localhost`. Can test by trying to add a dummy client with connection manager. Leave `host` blank and you'd get a server error.