### PR TITLE
Fix "account not found" error

### DIFF
--- a/scripts/pagination-test-wallets.js
+++ b/scripts/pagination-test-wallets.js
@@ -132,7 +132,7 @@ module.exports = async (node, config, logger, wallet) => {
       for (let o = 0; o < numOutputs; o++) {
         const recWallet = wallets[Math.floor(Math.random() * wallets.length)];
         const recAcct =
-          accountNames[Math.floor(Math.random() * wallets.length)];
+          accountNames[Math.floor(Math.random() * accountNames.length)];
 
         const recAddr = await recWallet.receiveAddress(recAcct);
         const value = Math.floor(


### PR DESCRIPTION
Sorry dunno how this wasn't obvious in my testing. There's way more wallets than accounts so its very likely that it would not be able to randomly find an account, because the array index would have been out of range. I stumbled on this using this script externally form bpanel to test bcoin.