### PR TITLE
fix docker image

### DIFF
--- a/Dockerfile-bcoin
+++ b/Dockerfile-bcoin
@@ -14,7 +14,7 @@ FROM base AS build
 RUN pacman -Syu --noconfirm base-devel unrar git python2 \
     && ln -s /usr/bin/python2 /usr/bin/python
 
-ARG repo=bcoin-org/bcoin
+ARG repo=bpanel-org/bcoin#experimental
 
 # use this to bust the build cache
 ARG rebuild=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
 
   bcoin:
     ## Use image to to pull from docker hub
-    image: bpanel/bcoin:experimental
+    image: bpanel/bcoin
     ## Build to use local Dockerfile-bcoin
     # build:
     #   context: .


### PR DESCRIPTION
Closes #184 

- `docker-compose` should now grab [dockerhub bpanel/bcoin image](https://hub.docker.com/r/bpanel/bcoin) `latest` tag

- The latest tag should be automatically built from `Dockerfile-bcoin` in this repo, development branch.

- That file now pulls from the bpanel-org/bcoin experimental branch